### PR TITLE
Move Modbus simulator into broker project

### DIFF
--- a/script/submodule-pre-commit.sh
+++ b/script/submodule-pre-commit.sh
@@ -2,6 +2,8 @@
 # Capture submodule changes as patch files during pre-commit and reset submodules.
 set -euo pipefail
 
+unset GIT_INDEX_FILE
+
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 PATCH_ROOT="$ROOT_DIR/submodule-patches"
 mkdir -p "$PATCH_ROOT"

--- a/submodule-patches/external/Homeassistant-Growatt-Local-Modbus/20250916-195747.patch
+++ b/submodule-patches/external/Homeassistant-Growatt-Local-Modbus/20250916-195747.patch
@@ -1,0 +1,2892 @@
+diff --git a/AGENTS.md b/AGENTS.md
+index 6520998..0db8d54 100644
+--- a/AGENTS.md
++++ b/AGENTS.md
+@@ -25,7 +25,7 @@ This repository tracks work on expanding Growatt inverter support for Home Assis
+ 
+ 5. **Broker usage policy**
+   - The broker project is **not** to be used directly in this repository for development or testing.
+-  - For dry-run and container testing, always use the Modbus simulator (`testing/modbus_simulator.py`).
++  - For dry-run and container testing, always use the Modbus simulator now provided by the broker package (`python -m growatt_broker.simulator.modbus_simulator`).
+   - The broker may be used only to generate static datasets for the simulator, which should then be copied into the Growatt repo.
+   - Do not add broker dependencies or startup logic to this repository.
+   - See `testing/README.md` for simulator usage and dataset provenance.
+diff --git a/README.md b/README.md
+index 1db4f61..1ebf1d8 100644
+--- a/README.md
++++ b/README.md
+@@ -37,7 +37,7 @@ Recent updates expose additional energy-flow information for hybrid models:
+ ### Recently added features
+ 
+ - **Complete register map** for MIN 6000XH-TL (see `testing/growatt_registers.md`)
+-- **Static simulator** (`testing/modbus_simulator.py`) with deterministic and realistic datasets
++- **Static simulator** (`growatt_broker.simulator.modbus_simulator`) with deterministic and realistic datasets
+ - **VS Code devcontainer forked from HA core** ([repo](https://github.com/l4m4re/HA-core/tree/growatt-local-test))
+ - **Pytest environment** with comprehensive tests
+ - **Synergy with external broker project** for dataset generation (not a runtime dependency)
+@@ -48,7 +48,7 @@ The register mapping for MIN 6000XH-TL is complete as far as currently determine
+ 
+ ### Simulator
+ 
+-- The simulator (`testing/modbus_simulator.py`) supports static and deterministic datasets, mutation plug-ins, and is used for both manual and automated tests.
++- The simulator (`growatt_broker.simulator.modbus_simulator`) supports static and deterministic datasets, mutation plug-ins, and is used for both manual and automated tests.
+ - By default, it simulates a MIN 6000XH-TL with battery.
+ - See [`testing/README.md`](testing/README.md) for advanced usage, mutation plug-ins, and dataset provenance.
+ 
+@@ -116,8 +116,8 @@ python testing/probe_simulator.py
+ 
+ 3. **Run the simulator:**
+     ```bash
+-    cd external/Homeassistant-Growatt-Local-Modbus/testing
+-    python modbus_simulator.py
++    cd external/Homeassistant-Growatt-Local-Modbus
++    python -m growatt_broker.simulator.modbus_simulator
+     ```
+     - By default, this simulates a MIN 6000XH-TL inverter on TCP port 5020.
+ 
+diff --git a/scripts/dev-start.sh b/scripts/dev-start.sh
+index 7fe6657..644306e 100755
+--- a/scripts/dev-start.sh
++++ b/scripts/dev-start.sh
+@@ -12,7 +12,6 @@ fi
+ VENVDIR=$BASE/.venv
+ HACONF=$BASE/ha_config
+ BROKER_LOG=$HACONF/broker.out
+-DATASET=$BASE/testing/datasets/min_6000xh_tl.json
+ PIDDIR=$BASE/.pids
+ SIM_PID_FILE=$PIDDIR/sim.pid
+ 
+@@ -40,7 +39,7 @@ start_simulator() {
+     echo "[dev-start] Simulator already running (PID $(cat "$SIM_PID_FILE"))"; return 0; fi
+   activate
+   echo "[dev-start] Starting Modbus simulator..."
+-  nohup python testing/modbus_simulator.py --dataset "$DATASET" & echo $! > "$SIM_PID_FILE"
++  nohup python -m growatt_broker.simulator.modbus_simulator & echo $! > "$SIM_PID_FILE"
+   sleep 2
+   if is_running "$SIM_PID_FILE"; then echo "[dev-start] Simulator started PID $(cat "$SIM_PID_FILE")"; else echo "[dev-start] Simulator failed"; fi
+ }
+diff --git a/scripts/start-serial-simulator.sh b/scripts/start-serial-simulator.sh
+index c8b5896..8a3e64c 100755
+--- a/scripts/start-serial-simulator.sh
++++ b/scripts/start-serial-simulator.sh
+@@ -53,7 +53,7 @@ echo "Client serial port: ${CLIENT_PORT}" >&2
+ printf '%s\n' "${CLIENT_PORT}"
+ 
+ PYTHON_BIN=${PYTHON:-python}
+-"${PYTHON_BIN}" "${REPO_ROOT}/testing/modbus_simulator.py" --mode serial --serial-port "${SIM_PORT}" "$@" &
++"${PYTHON_BIN}" -m growatt_broker.simulator.modbus_simulator --mode serial --serial-port "${SIM_PORT}" "$@" &
+ SIM_PID=$!
+ 
+ wait "${SIM_PID}"
+diff --git a/testing/README.md b/testing/README.md
+index 736450b..99f5788 100644
+--- a/testing/README.md
++++ b/testing/README.md
+@@ -19,8 +19,8 @@ This guide describes how to use, test, and extend the Growatt Local Modbus integ
+ 
+ 3. **Run the simulator:**
+   ```bash
+-  cd external/Homeassistant-Growatt-Local-Modbus/testing
+-  python modbus_simulator.py
++  cd external/Homeassistant-Growatt-Local-Modbus
++  python -m growatt_broker.simulator.modbus_simulator
+   ```
+   - By default, this simulates a MIN 6000XH-TL inverter on TCP port 5020.
+ 
+@@ -42,7 +42,7 @@ This guide describes how to use, test, and extend the Growatt Local Modbus integ
+ 
+ ## Simulator Usage
+ 
+-- The simulator (`modbus_simulator.py`) supports static and deterministic datasets, mutation plug-ins, and is used for both manual and automated tests.
++- The simulator (`growatt_broker.simulator.modbus_simulator`) supports static and deterministic datasets, mutation plug-ins, and is used for both manual and automated tests.
+ - By default, it simulates a MIN 6000XH-TL with battery.
+ - Use the `--force-deterministic` flag for stable test values.
+ - See below for advanced usage, mutation plug-ins, and dataset provenance.
+@@ -301,6 +301,8 @@ The script writes four outputs:
+ * `input_min.json`
+ * `input_tl_xh.json`
+ 
++After generating new definitions, copy them into `../external/growatt-rtu-broker/growatt_broker/simulator/` so the shared simulator picks up the updates.
++
+ Each entry records register number, function code, length, scale, unit,
+ and description for the corresponding device type.
+ 
+@@ -308,7 +310,7 @@ and description for the corresponding device type.
+ 
+ ## Dataset provenance (simulation)
+ 
+-The default simulator dataset `datasets/min_6000xh_tl.json` was generated from
++The default simulator dataset `growatt_broker/simulator/datasets/min_6000xh_tl.json` was generated from
+ `scan3.txt` contained in this repository under `python-modbus-scanner/`.
+ That scan originated from (and the scanner utility lives at):
+ 
+@@ -322,12 +324,12 @@ If you regenerate it, you can run:
+ ```bash
+ python testing/build_dataset_from_scan.py \
+   --scan-file testing/python-modbus-scanner/scan3.txt \
+-  --out testing/datasets/min_6000xh_tl.json
++  --out ../external/growatt-rtu-broker/growatt_broker/simulator/datasets/min_6000xh_tl.json
+ ```
+ 
+ Then restart any running simulator instance.
+ 
+-**Note:** The full broker project is only used to generate static datasets for the simulator. All dry-run and container testing should use the Modbus simulator (`testing/modbus_simulator.py`). Do not use the broker directly for development or testing in this repository.
++**Note:** The full broker project is only used to generate static datasets for the simulator. All dry-run and container testing should use the Modbus simulator provided by the broker package (`python -m growatt_broker.simulator.modbus_simulator`). Do not use the broker directly for development or testing in this repository.
+ 
+ To annotate a dataset with a provenance tag without breaking the loader you
+ may add a top‑level `_source` field, e.g.:
+@@ -377,7 +379,7 @@ Both simulator and broker CLIs choose the backend; higher‑level frontends (Mod
+ 1. Run broker in capture mode while HA (or any Modbus client) polls.
+ 2. Broker appends JSONL events (unit, func, addr, values, timestamp).
+ 3. A helper script (shared or here) compacts events into `holding` / `input` dicts, preserving last‑seen value per register.
+-4. Write `testing/datasets/<device>.json` (optionally add `_source`).
++4. Write `../external/growatt-rtu-broker/growatt_broker/simulator/datasets/<device>.json` (optionally add `_source`).
+ 5. Simulator consumes the new dataset for offline regression or CI.
+ 
+ ### Why keep projects separate?
+@@ -397,7 +399,7 @@ Both simulator and broker CLIs choose the backend; higher‑level frontends (Mod
+ ### Proposed roadmap
+ 1. Broker repo: introduce `DatasetBackend` & `CaptureBackend` (no breaking changes).
+ 2. Export a simple dataset capture CLI: `growatt-broker capture --out session.jsonl`.
+-3. Add compaction script here: `python testing/compact_capture.py --in session.jsonl --out testing/datasets/min_6000xh_tl_new.json`.
++3. Add compaction script here: `python testing/compact_capture.py --in session.jsonl --out ../external/growatt-rtu-broker/growatt_broker/simulator/datasets/min_6000xh_tl_new.json`.
+ 4. Extend simulator to accept a mutation plug‑in (e.g., auto‑increment energy counters) for long‑running test realism.
+ 5. Add README section (this one) linking broker usage; document optional Modbus TCP integration.
+ 6. Provide a minimal Home Assistant add‑on definition for the broker (optional future).
+@@ -570,13 +572,13 @@ A fixture can:
+ # Start broker in capture mode (planned feature)
+ growatt-broker --inverter /dev/ttyUSB0 --capture session.jsonl --tcp 0.0.0.0:5020 &
+ # Run HA or probe tooling for N minutes
+-python testing/compact_capture.py --in session.jsonl --out testing/datasets/min_6000xh_tl_new.json --device min_6000xh_tl --source-tag "capture $(date +%F)"
++python testing/compact_capture.py --in session.jsonl --out ../external/growatt-rtu-broker/growatt_broker/simulator/datasets/min_6000xh_tl_new.json --device min_6000xh_tl --source-tag "capture $(date +%F)"
+ ```
+ Produces a dataset JSON you can rename / replace after validation.
+ 
+ **If --out omitted** the default path is:
+ ```
+-testing/datasets/<device>.json
++../external/growatt-rtu-broker/growatt_broker/simulator/datasets/<device>.json
+ ```
+ 
+ ---
+@@ -601,15 +603,15 @@ See `testing/mutators/sample_mutator.py`:
+ ### 15.3 Usage examples
+ Increment totals using the class:
+ ```bash
+-python testing/modbus_simulator.py --mutator testing.mutators.sample_mutator:EnergyIncrement
++python -m growatt_broker.simulator.modbus_simulator --mutator testing.mutators.sample_mutator:EnergyIncrement
+ ```
+ Use the function form:
+ ```bash
+-python testing/modbus_simulator.py --mutator testing.mutators.sample_mutator
++python -m growatt_broker.simulator.modbus_simulator --mutator testing.mutators.sample_mutator
+ ```
+ Combine multiple mutators:
+ ```bash
+-python testing/modbus_simulator.py \
++python -m growatt_broker.simulator.modbus_simulator \
+   --mutator testing.mutators.sample_mutator:EnergyIncrement \
+   --mutator testing.mutators.sample_mutator
+ ```
+diff --git a/testing/build_dataset_from_scan.py b/testing/build_dataset_from_scan.py
+index 7fbcc91..e8e485e 100644
+--- a/testing/build_dataset_from_scan.py
++++ b/testing/build_dataset_from_scan.py
+@@ -4,14 +4,15 @@ Parses lines like:
+   found holding register 331, value=4900
+   found input   register 2, value=14
+ 
+-Outputs JSON structure consumable by `modbus_simulator.py` datasets:
++Outputs JSON structure consumable by `growatt_broker.simulator.modbus_simulator` datasets:
+ {
+   "holding": {"331": 4900, ...},
+   "input": {"2": 14, ...}
+ }
+ 
+ Usage:
+-  python build_dataset_from_scan.py --scan-file python-modbus-scanner/scan3.txt --out datasets/min_6000xh_tl_from_scan3.json
++  python build_dataset_from_scan.py --scan-file python-modbus-scanner/scan3.txt \
++    --out ../external/growatt-rtu-broker/growatt_broker/simulator/datasets/min_6000xh_tl_from_scan3.json
+ """
+ 
+ from __future__ import annotations
+diff --git a/testing/compact_capture.py b/testing/compact_capture.py
+index e684974..c889a70 100644
+--- a/testing/compact_capture.py
++++ b/testing/compact_capture.py
+@@ -2,9 +2,9 @@
+ 
+ Usage:
+   python testing/compact_capture.py --in session.jsonl --device min_6000xh_tl \
+-      --out testing/datasets/min_6000xh_tl_new.json
++      --out ../external/growatt-rtu-broker/growatt_broker/simulator/datasets/min_6000xh_tl_new.json
+ 
+-If --out is omitted it writes to testing/datasets/<device>.json
++If --out is omitted it writes to the broker simulator datasets directory (<repo>/external/growatt-rtu-broker/growatt_broker/simulator/datasets/<device>.json)
+ Keeps the *last* observed value for each register per function.
+ Accepts events produced by CaptureBackend (ops: read_input, read_holding).
+ """
+@@ -12,6 +12,14 @@ from __future__ import annotations
+ import argparse, json, pathlib, sys
+ from typing import Dict, List
+ 
++DEFAULT_DATASET_DIR = (
++    pathlib.Path(__file__).resolve().parents[2]
++    / "growatt-rtu-broker"
++    / "growatt_broker"
++    / "simulator"
++    / "datasets"
++)
++
+ OP_MAP = {"read_input": "input", "read_holding": "holding"}
+ 
+ def load_events(path: pathlib.Path):
+@@ -46,7 +54,12 @@ def main(argv=None):
+     ap = argparse.ArgumentParser(description="Compact capture JSONL to dataset JSON")
+     ap.add_argument("--in", required=True, dest="inp", help="Input capture JSONL file")
+     ap.add_argument("--device", required=True, help="Device key used for default output name")
+-    ap.add_argument("--out", help="Output dataset JSON file (default: testing/datasets/<device>.json)")
++    ap.add_argument(
++        "--out",
++        help=(
++            "Output dataset JSON file (default: broker simulator datasets/<device>.json)"
++        ),
++    )
+     ap.add_argument("--source-tag", help="Optional provenance tag (_source field)")
+     args = ap.parse_args(argv)
+ 
+@@ -55,7 +68,11 @@ def main(argv=None):
+         print(f"[ERROR] input file not found: {in_path}", file=sys.stderr)
+         return 2
+ 
+-    out_path = pathlib.Path(args.out) if args.out else pathlib.Path("testing/datasets") / f"{args.device}.json"
++    out_path = (
++        pathlib.Path(args.out)
++        if args.out
++        else DEFAULT_DATASET_DIR / f"{args.device}.json"
++    )
+     out_path.parent.mkdir(parents=True, exist_ok=True)
+ 
+     data = compact(load_events(in_path))
+diff --git a/testing/datasets/min_6000xh_tl.json b/testing/datasets/min_6000xh_tl.json
+deleted file mode 100644
+index 12ec073..0000000
+--- a/testing/datasets/min_6000xh_tl.json
++++ /dev/null
+@@ -1,400 +0,0 @@
+-{
+-  "_source": "Derived from scan3.txt in python-modbus-scanner (local copy in testing/python-modbus-scanner/scan3.txt)",
+-  "holding": {
+-    "3": 100,
+-    "5": 10000,
+-    "7": -5536,
+-    "8": 1000,
+-    "9": 16716,
+-    "10": 12590,
+-    "11": 12288,
+-    "13": 25185,
+-    "14": 29,
+-    "15": 1,
+-    "17": 1000,
+-    "18": 60,
+-    "19": 60,
+-    "20": 100,
+-    "21": 100,
+-    "22": 1,
+-    "23": 21326,
+-    "24": 19504,
+-    "25": 17223,
+-    "26": 22064,
+-    "27": 12848,
+-    "30": 1,
+-    "31": 100,
+-    "34": 8224,
+-    "35": 8272,
+-    "36": 22048,
+-    "37": 18798,
+-    "38": 30309,
+-    "39": 29300,
+-    "40": 25970,
+-    "41": 8224,
+-    "43": 5100,
+-    "44": 513,
+-    "45": 2023,
+-    "46": 9,
+-    "47": 6,
+-    "48": 21,
+-    "49": 24,
+-    "50": 2,
+-    "51": 3,
+-    "52": 1840,
+-    "53": 2645,
+-    "54": 4750,
+-    "55": 5150,
+-    "56": 1610,
+-    "57": 2645,
+-    "58": 4750,
+-    "59": 5150,
+-    "60": 1610,
+-    "61": 2645,
+-    "62": 4750,
+-    "63": 5150,
+-    "64": 1955,
+-    "65": 2530,
+-    "66": 4990,
+-    "67": 5010,
+-    "68": 100,
+-    "69": 50,
+-    "70": 50,
+-    "71": 50,
+-    "72": 50,
+-    "73": 50,
+-    "74": 50,
+-    "75": 50,
+-    "76": 50,
+-    "77": 50,
+-    "78": 10,
+-    "79": 10,
+-    "80": 2530,
+-    "82": 16716,
+-    "83": 25185,
+-    "84": 12592,
+-    "85": 12337,
+-    "86": 12337,
+-    "87": 12857,
+-    "88": 305,
+-    "91": 5020,
+-    "92": 50,
+-    "93": 2484,
+-    "94": 2530,
+-    "95": 2116,
+-    "96": 2070,
+-    "97": 20,
+-    "98": 5,
+-    "99": 2415,
+-    "100": 2300,
+-    "101": 10000,
+-    "102": 10000,
+-    "103": 10000,
+-    "104": 10000,
+-    "105": 10000,
+-    "106": 10000,
+-    "107": 150,
+-    "109": 484,
+-    "110": 255,
+-    "111": 20000,
+-    "112": 255,
+-    "113": 20000,
+-    "114": 255,
+-    "115": 20000,
+-    "116": 255,
+-    "117": 20000,
+-    "118": 15880,
+-    "120": 3841,
+-    "121": 60,
+-    "125": 20566,
+-    "126": 8224,
+-    "127": 8246,
+-    "128": 12336,
+-    "129": 12320,
+-    "130": 8224,
+-    "131": 8224,
+-    "132": 8192,
+-    "142": 4975,
+-    "143": 5020,
+-    "146": 1150,
+-    "147": 2760,
+-    "148": 2530,
+-    "149": 2530,
+-    "150": 100,
+-    "151": 4990,
+-    "153": 4800,
+-    "155": 5200,
+-    "176": 50,
+-    "177": 5020,
+-    "180": 1,
+-    "209": 21326,
+-    "210": 19504,
+-    "211": 17223,
+-    "212": 22064,
+-    "213": 12848,
+-    "226": 900,
+-    "235": 1,
+-    "239": 239,
+-    "251": 1001,
+-    "252": 1002,
+-    "253": 1003,
+-    "254": 1004,
+-    "255": 8,
+-    "256": 4,
+-    "257": 3,
+-    "258": 1,
+-    "307": 30,
+-    "331": 4900,
+-    "332": 5075,
+-    "344": 4600,
+-    "345": 6500,
+-    "501": 10,
+-    "502": 1,
+-    "507": 72,
+-    "508": 1,
+-    "509": 1,
+-    "533": 1,
+-    "534": 6250,
+-    "541": 160,
+-    "544": 3000,
+-    "545": 6000,
+-    "546": 9000,
+-    "547": 40,
+-    "551": 1200,
+-    "600": 484,
+-    "603": 484,
+-    "3001": 21326,
+-    "3002": 19504,
+-    "3003": 17223,
+-    "3004": 22064,
+-    "3005": 12848,
+-    "3017": 500,
+-    "3019": 400,
+-    "3020": -30207,
+-    "3022": 5500,
+-    "3024": 600,
+-    "3030": 5800,
+-    "3036": 15,
+-    "3037": 15,
+-    "3038": -32768,
+-    "3039": 5947,
+-    "3041": 59,
+-    "3043": 59,
+-    "3047": 50,
+-    "3048": 90,
+-    "3079": 1,
+-    "3087": 20817,
+-    "3088": 19249,
+-    "3089": 12336,
+-    "3090": 12336,
+-    "3091": 12850,
+-    "3092": 12338,
+-    "3093": 12336,
+-    "3094": 14667,
+-    "3096": 23109,
+-    "3097": 16961,
+-    "3099": 22083,
+-    "3100": 16705,
+-    "3101": 2,
+-    "3102": 2616,
+-    "3103": 2,
+-    "3104": 2,
+-    "3105": 732,
+-    "3108": 16,
+-    "3109": 1024,
+-    "3111": 48,
+-    "3113": 257,
+-    "3114": 10,
+-    "3125": 22616,
+-    "3126": 22616,
+-    "3127": 22616,
+-    "3128": 22616,
+-    "3136": 8224,
+-    "3137": 8224
+-  },
+-  "input": {
+-    "1": 1,
+-    "2": 2,
+-    "3": 14,
+-    "4": 262,
+-    "6": 4,
+-    "7": 357,
+-    "10": 10,
+-    "36": 6826,
+-    "37": 5000,
+-    "38": 2278,
+-    "39": 29,
+-    "41": 6827,
+-    "50": 2278,
+-    "54": 275,
+-    "56": 14039,
+-    "57": 152,
+-    "58": -28497,
+-    "60": 121,
+-    "62": 5969,
+-    "64": 166,
+-    "66": 8922,
+-    "92": 14891,
+-    "93": 401,
+-    "94": 401,
+-    "96": 457,
+-    "97": 423,
+-    "98": 3868,
+-    "100": 20000,
+-    "113": 11,
+-    "114": 60,
+-    "182": 1,
+-    "183": 1,
+-    "189": 26,
+-    "190": 35,
+-    "191": 375,
+-    "192": 6000,
+-    "193": 1,
+-    "194": 9,
+-    "195": 7,
+-    "196": 2,
+-    "200": -6,
+-    "201": 1,
+-    "207": 664,
+-    "285": 6,
+-    "287": 6,
+-    "289": 8,
+-    "291": 6,
+-    "293": 16,
+-    "295": 23,
+-    "297": 23,
+-    "299": 22,
+-    "301": 26,
+-    "303": 31,
+-    "305": 32,
+-    "307": 32,
+-    "309": 18,
+-    "311": 4,
+-    "313": 2,
+-    "315": 2,
+-    "317": 3,
+-    "319": 2,
+-    "321": 2,
+-    "323": 2,
+-    "325": 2,
+-    "327": 2,
+-    "329": 5,
+-    "331": 5,
+-    "333": 275,
+-    "335": 268,
+-    "337": 258,
+-    "339": 225,
+-    "341": 142,
+-    "343": 99,
+-    "345": 248,
+-    "347": 1267,
+-    "349": 6772,
+-    "351": 5659,
+-    "365": 341,
+-    "376": 14039,
+-    "802": 1,
+-    "815": 6829,
+-    "3000": 1,
+-    "3002": 14,
+-    "3003": 262,
+-    "3006": 3,
+-    "3007": 357,
+-    "3010": 11,
+-    "3020": 7034,
+-    "3024": 6775,
+-    "3025": 4998,
+-    "3026": 2280,
+-    "3027": 30,
+-    "3029": 6776,
+-    "3038": 2280,
+-    "3046": 7074,
+-    "3047": 152,
+-    "3048": -28393,
+-    "3050": 275,
+-    "3052": 14039,
+-    "3054": 14891,
+-    "3056": 121,
+-    "3058": 5969,
+-    "3060": 166,
+-    "3062": 8922,
+-    "3068": 9,
+-    "3070": 1643,
+-    "3072": 181,
+-    "3074": 6425,
+-    "3076": 118,
+-    "3078": 9968,
+-    "3084": 287,
+-    "3087": -6,
+-    "3093": 401,
+-    "3094": 401,
+-    "3097": 422,
+-    "3098": 3867,
+-    "3100": 20000,
+-    "3101": 11,
+-    "3109": 712,
+-    "3110": 712,
+-    "3111": 290,
+-    "3115": 60,
+-    "3118": 1,
+-    "3122": 7144,
+-    "3124": 290,
+-    "3126": 53,
+-    "3128": 2240,
+-    "3130": 50,
+-    "3132": 2381,
+-    "3136": 44,
+-    "3138": 14799,
+-    "3140": 109,
+-    "3142": 8376,
+-    "3161": 10000,
+-    "3163": 3900,
+-    "3165": 22,
+-    "3166": 513,
+-    "3169": 21017,
+-    "3170": 33,
+-    "3171": 63,
+-    "3172": 3899,
+-    "3173": 1988,
+-    "3174": 15,
+-    "3175": 15,
+-    "3176": 377,
+-    "3179": 7080,
+-    "3183": 2240,
+-    "3185": 2381,
+-    "3187": 3,
+-    "3188": 1911,
+-    "3189": 59,
+-    "3190": 41,
+-    "3192": 310,
+-    "3193": 287,
+-    "3194": 2,
+-    "3195": 14,
+-    "3198": 1,
+-    "3200": 50,
+-    "3201": 50,
+-    "3212": 2,
+-    "3215": 63,
+-    "3216": 21000,
+-    "3217": -340,
+-    "3218": 480,
+-    "3219": 2500,
+-    "3220": 2500,
+-    "3222": 100,
+-    "3223": 22720,
+-    "3224": 18880,
+-    "3227": 10536,
+-    "3230": 3269,
+-    "3231": 3265,
+-    "3232": 21010,
+-    "3234": 1,
+-    "3235": 1,
+-    "3241": 26,
+-    "3242": 35,
+-    "3243": 375,
+-    "3244": 6000,
+-    "3245": 1,
+-    "3246": 9,
+-    "3247": 7,
+-    "3248": 2
+-  }
+-}
+\ No newline at end of file
+diff --git a/testing/holding_min.json b/testing/holding_min.json
+deleted file mode 100644
+index ad1520d..0000000
+--- a/testing/holding_min.json
++++ /dev/null
+@@ -1,434 +0,0 @@
+-[
+-  {
+-    "number": 0,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Remote On/Off"
+-  },
+-  {
+-    "number": 3,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Max active power %"
+-  },
+-  {
+-    "number": 5,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 10000,
+-    "unit": "-",
+-    "description": "Power factor ×10000"
+-  },
+-  {
+-    "number": 7,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "VA",
+-    "description": "Normal power setting"
+-  },
+-  {
+-    "number": 9,
+-    "function_code": "03",
+-    "length": 3,
+-    "scale": 1,
+-    "unit": "ASCII",
+-    "description": "Firmware version"
+-  },
+-  {
+-    "number": 12,
+-    "function_code": "03",
+-    "length": 3,
+-    "scale": 1,
+-    "unit": "ASCII",
+-    "description": "Control firmware version"
+-  },
+-  {
+-    "number": 15,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "code",
+-    "description": "LCD language"
+-  },
+-  {
+-    "number": 17,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV start voltage"
+-  },
+-  {
+-    "number": 18,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "s",
+-    "description": "Start time"
+-  },
+-  {
+-    "number": 19,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "s",
+-    "description": "Restart delay after fault"
+-  },
+-  {
+-    "number": 20,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "%/s",
+-    "description": "Power slope settings"
+-  },
+-  {
+-    "number": 22,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Baud rate selection"
+-  },
+-  {
+-    "number": 23,
+-    "function_code": "03",
+-    "length": 5,
+-    "scale": 1,
+-    "unit": "str",
+-    "description": "Serial number (ASCII)"
+-  },
+-  {
+-    "number": 28,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "str",
+-    "description": "Inverter model"
+-  },
+-  {
+-    "number": 30,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Communication address"
+-  },
+-  {
+-    "number": 31,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Flash update trigger"
+-  },
+-  {
+-    "number": 34,
+-    "function_code": "03",
+-    "length": 8,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Manufacturer info"
+-  },
+-  {
+-    "number": 43,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "`ATTR_DEVICE_TYPE_CODE`",
+-    "description": "Device type code"
+-  },
+-  {
+-    "number": 44,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "`ATTR_NUMBER_OF_TRACKERS_AND_PHASES`",
+-    "description": "Tracker + phase count"
+-  },
+-  {
+-    "number": 45,
+-    "function_code": "03",
+-    "length": 6,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Device system time (Y/M/D/H/M/S)"
+-  },
+-  {
+-    "number": 82,
+-    "function_code": "03",
+-    "length": 6,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "FW build numbers (ASCII)"
+-  },
+-  {
+-    "number": 88,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "`ATTR_MODBUS_VERSION`",
+-    "description": "Modbus version ×100"
+-  },
+-  {
+-    "number": 0,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Remote On/Off (Inverter/BDC)"
+-  },
+-  {
+-    "number": 1,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Safety function enable bits"
+-  },
+-  {
+-    "number": 2,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "PF CMD memory state"
+-  },
+-  {
+-    "number": 3,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Active P rate (limit %)"
+-  },
+-  {
+-    "number": 4,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Reactive P rate (limit %)"
+-  },
+-  {
+-    "number": 5,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 10000,
+-    "unit": "–",
+-    "description": "Power factor ×10000"
+-  },
+-  {
+-    "number": 6,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "VA",
+-    "description": "Pmax (high/low)"
+-  },
+-  {
+-    "number": 8,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "Vnormal (PV work voltage)"
+-  },
+-  {
+-    "number": 9,
+-    "function_code": "03",
+-    "length": 3,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Firmware version (H/M/L)"
+-  },
+-  {
+-    "number": 12,
+-    "function_code": "03",
+-    "length": 3,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Control FW version (H/M/L)"
+-  },
+-  {
+-    "number": 15,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "LCD language"
+-  },
+-  {
+-    "number": 16,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Country selected"
+-  },
+-  {
+-    "number": 17,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV start voltage"
+-  },
+-  {
+-    "number": 18,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "s",
+-    "description": "Start / Restart delay"
+-  },
+-  {
+-    "number": 20,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "0.1%",
+-    "description": "Power start / restart slope"
+-  },
+-  {
+-    "number": 22,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Baudrate select (0=9600,1=38400)"
+-  },
+-  {
+-    "number": 23,
+-    "function_code": "03",
+-    "length": 5,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Serial number (1–10)"
+-  },
+-  {
+-    "number": 28,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Inverter Module (model code)"
+-  },
+-  {
+-    "number": 30,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Modbus address"
+-  },
+-  {
+-    "number": 31,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "FlashStart (FW update)"
+-  },
+-  {
+-    "number": 32,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Reset user info / factory"
+-  },
+-  {
+-    "number": 34,
+-    "function_code": "03",
+-    "length": 8,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Manufacturer info (8..1)"
+-  },
+-  {
+-    "number": 42,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "G100 fail safe"
+-  },
+-  {
+-    "number": 43,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Device Type Code"
+-  },
+-  {
+-    "number": 44,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Trackers & phases"
+-  },
+-  {
+-    "number": 45,
+-    "function_code": "03",
+-    "length": 7,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "System time (Y/M/D/h/m/s/weekday)"
+-  },
+-  {
+-    "number": 52,
+-    "function_code": "03",
+-    "length": 16,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Grid protection limits"
+-  },
+-  {
+-    "number": 68,
+-    "function_code": "03",
+-    "length": 12,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Grid protection times"
+-  },
+-  {
+-    "number": 80,
+-    "function_code": "03",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "10‑min voltage / PV over‑V fault"
+-  },
+-  {
+-    "number": 82,
+-    "function_code": "03",
+-    "length": 6,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "FW build numbers"
+-  },
+-  {
+-    "number": 88,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "–",
+-    "description": "Modbus version ×100"
+-  },
+-  {
+-    "number": 89,
+-    "function_code": "03",
+-    "length": 11,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "PF/Q(V)/derating controls"
+-  }
+-]
+\ No newline at end of file
+diff --git a/testing/holding_tl_xh.json b/testing/holding_tl_xh.json
+deleted file mode 100644
+index ea68aa1..0000000
+--- a/testing/holding_tl_xh.json
++++ /dev/null
+@@ -1,18 +0,0 @@
+-[
+-  {
+-    "number": 3001,
+-    "function_code": "03",
+-    "length": 15,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Serial number (ASCII, 15 words)"
+-  },
+-  {
+-    "number": 3049,
+-    "function_code": "03",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "AC charge enable"
+-  }
+-]
+\ No newline at end of file
+diff --git a/testing/input_min.json b/testing/input_min.json
+deleted file mode 100644
+index 65952ca..0000000
+--- a/testing/input_min.json
++++ /dev/null
+@@ -1,450 +0,0 @@
+-[
+-  {
+-    "number": 0,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "int",
+-    "description": "Status code"
+-  },
+-  {
+-    "number": 1,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "Total PV input power"
+-  },
+-  {
+-    "number": 3,
+-    "function_code": "04",
+-    "length": 4,
+-    "scale": 1,
+-    "unit": "V/A/W",
+-    "description": "PV1 V/A/P"
+-  },
+-  {
+-    "number": 7,
+-    "function_code": "04",
+-    "length": 4,
+-    "scale": 1,
+-    "unit": "V/A/W",
+-    "description": "PV2 V/A/P"
+-  },
+-  {
+-    "number": 35,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "Output power"
+-  },
+-  {
+-    "number": 37,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "Hz",
+-    "description": "Grid frequency"
+-  },
+-  {
+-    "number": 38,
+-    "function_code": "04",
+-    "length": 3,
+-    "scale": 1,
+-    "unit": "V/A/W",
+-    "description": "AC1 V/A/P"
+-  },
+-  {
+-    "number": 53,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Today’s output energy"
+-  },
+-  {
+-    "number": 55,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Total output energy"
+-  },
+-  {
+-    "number": 57,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "h",
+-    "description": "Operation hours"
+-  },
+-  {
+-    "number": 59,
+-    "function_code": "04",
+-    "length": 8,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV1+PV2 today & total energy"
+-  },
+-  {
+-    "number": 91,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV total energy"
+-  },
+-  {
+-    "number": 93,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "Inverter temp"
+-  },
+-  {
+-    "number": 94,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "IPM temp"
+-  },
+-  {
+-    "number": 98,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "P-bus voltage"
+-  },
+-  {
+-    "number": 99,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "N-bus voltage"
+-  },
+-  {
+-    "number": 101,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Output %"
+-  },
+-  {
+-    "number": 104,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Derating mode"
+-  },
+-  {
+-    "number": 105,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Fault code"
+-  },
+-  {
+-    "number": 110,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Warning code"
+-  },
+-  {
+-    "number": 0,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Status code"
+-  },
+-  {
+-    "number": 1,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "PV total input power"
+-  },
+-  {
+-    "number": 3,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV1 voltage"
+-  },
+-  {
+-    "number": 4,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "A",
+-    "description": "PV1 current"
+-  },
+-  {
+-    "number": 5,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "PV1 power"
+-  },
+-  {
+-    "number": 7,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV2 voltage"
+-  },
+-  {
+-    "number": 8,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "A",
+-    "description": "PV2 current"
+-  },
+-  {
+-    "number": 9,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "PV2 power"
+-  },
+-  {
+-    "number": 11,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV3 voltage"
+-  },
+-  {
+-    "number": 12,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "A",
+-    "description": "PV3 current"
+-  },
+-  {
+-    "number": 13,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "PV3 power"
+-  },
+-  {
+-    "number": 15,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "PV4 voltage"
+-  },
+-  {
+-    "number": 16,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "A",
+-    "description": "PV4 current"
+-  },
+-  {
+-    "number": 17,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "PV4 power"
+-  },
+-  {
+-    "number": 35,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "Output (AC) power"
+-  },
+-  {
+-    "number": 37,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "Hz",
+-    "description": "Grid frequency"
+-  },
+-  {
+-    "number": 38,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "AC1 voltage"
+-  },
+-  {
+-    "number": 39,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "A",
+-    "description": "AC1 current"
+-  },
+-  {
+-    "number": 40,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "AC1 power"
+-  },
+-  {
+-    "number": 42,
+-    "function_code": "04",
+-    "length": 7,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "AC2/AC3 (3‑phase models)"
+-  },
+-  {
+-    "number": 53,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Today’s output energy"
+-  },
+-  {
+-    "number": 55,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Total output energy"
+-  },
+-  {
+-    "number": 57,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "h",
+-    "description": "Operation hours"
+-  },
+-  {
+-    "number": 59,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV1 today’s energy"
+-  },
+-  {
+-    "number": 61,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV1 total energy"
+-  },
+-  {
+-    "number": 63,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV2 today’s energy"
+-  },
+-  {
+-    "number": 65,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV2 total energy"
+-  },
+-  {
+-    "number": 91,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "PV total energy"
+-  },
+-  {
+-    "number": 93,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "Inverter temperature"
+-  },
+-  {
+-    "number": 94,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "IPM temperature"
+-  },
+-  {
+-    "number": 98,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "DC bus voltage P"
+-  },
+-  {
+-    "number": 99,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "V",
+-    "description": "DC bus voltage N"
+-  },
+-  {
+-    "number": 101,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Real output %"
+-  },
+-  {
+-    "number": 104,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Derating mode"
+-  },
+-  {
+-    "number": 105,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Fault code"
+-  },
+-  {
+-    "number": 110,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "–",
+-    "description": "Warning code"
+-  }
+-]
+\ No newline at end of file
+diff --git a/testing/input_tl_xh.json b/testing/input_tl_xh.json
+deleted file mode 100644
+index 57345a2..0000000
+--- a/testing/input_tl_xh.json
++++ /dev/null
+@@ -1,298 +0,0 @@
+-[
+-  {
+-    "number": 3125,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Battery discharge today"
+-  },
+-  {
+-    "number": 3127,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Battery discharge total"
+-  },
+-  {
+-    "number": 3129,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Battery charge today"
+-  },
+-  {
+-    "number": 3131,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "kWh",
+-    "description": "Battery charge total"
+-  },
+-  {
+-    "number": 3164,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BDC new flag"
+-  },
+-  {
+-    "number": 3171,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "Battery SOC %"
+-  },
+-  {
+-    "number": 3176,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "Battery temp A"
+-  },
+-  {
+-    "number": 3177,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "Battery temp B"
+-  },
+-  {
+-    "number": 3178,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "Battery discharge power"
+-  },
+-  {
+-    "number": 3180,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "W",
+-    "description": "Battery charge power"
+-  },
+-  {
+-    "number": 3202,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Protect1"
+-  },
+-  {
+-    "number": 3203,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Warn1"
+-  },
+-  {
+-    "number": 3204,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Fault1"
+-  },
+-  {
+-    "number": 3205,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Fault2"
+-  },
+-  {
+-    "number": 3210,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Battery ISO detect status"
+-  },
+-  {
+-    "number": 3211,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "Battery request flags"
+-  },
+-  {
+-    "number": 3212,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS status"
+-  },
+-  {
+-    "number": 3213,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Protect2"
+-  },
+-  {
+-    "number": 3214,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Warn2"
+-  },
+-  {
+-    "number": 3215,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "BMS SOC"
+-  },
+-  {
+-    "number": 3216,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "V",
+-    "description": "BMS battery voltage"
+-  },
+-  {
+-    "number": 3217,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "A",
+-    "description": "BMS battery current"
+-  },
+-  {
+-    "number": 3218,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "°C",
+-    "description": "BMS cell max temperature"
+-  },
+-  {
+-    "number": 3219,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "A",
+-    "description": "BMS max charge current"
+-  },
+-  {
+-    "number": 3220,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "A",
+-    "description": "BMS max discharge current"
+-  },
+-  {
+-    "number": 3221,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS cycle count"
+-  },
+-  {
+-    "number": 3222,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "%",
+-    "description": "BMS state of health"
+-  },
+-  {
+-    "number": 3223,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "V",
+-    "description": "BMS charge voltage limit"
+-  },
+-  {
+-    "number": 3224,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 100,
+-    "unit": "V",
+-    "description": "BMS discharge voltage limit"
+-  },
+-  {
+-    "number": 3225,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Warn3"
+-  },
+-  {
+-    "number": 3226,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "-",
+-    "description": "BMS Protect3"
+-  },
+-  {
+-    "number": 3230,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1000,
+-    "unit": "V",
+-    "description": "BMS cell voltage max"
+-  },
+-  {
+-    "number": 3231,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1000,
+-    "unit": "V",
+-    "description": "BMS cell voltage min"
+-  },
+-  {
+-    "number": 3069,
+-    "function_code": "04",
+-    "length": 2,
+-    "scale": 1,
+-    "unit": "",
+-    "description": "32‑bit field (pair)"
+-  },
+-  {
+-    "number": 3097,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "",
+-    "description": "Communication board temperature"
+-  },
+-  {
+-    "number": 3111,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "",
+-    "description": "PresentFFTValue \\[CHANNEL_A]"
+-  },
+-  {
+-    "number": 3115,
+-    "function_code": "04",
+-    "length": 1,
+-    "scale": 1,
+-    "unit": "",
+-    "description": "Inverter start delay time"
+-  }
+-]
+\ No newline at end of file
+diff --git a/testing/modbus_simulator.py b/testing/modbus_simulator.py
+deleted file mode 100644
+index 0a80eb1..0000000
+--- a/testing/modbus_simulator.py
++++ /dev/null
+@@ -1,529 +0,0 @@
+-"""
+-Configurable Modbus TCP/RTU simulator for Growatt devices.
+-
+-Features:
+- - Support multiple device types via JSON register definition files
+- - Optional dataset JSON with realistic register values (e.g. based on real MIN 6000XH-TL scans)
+- - Supports TCP and serial (RTU) transports for integration and testing
+- - Re-usable async context manager for tests, plus CLI for manual use
+-
+-JSON definition format (existing):
+- [ {"number": 1, "name": "...", "length": 1}, ... ]
+-
+-Dataset JSON format:
+- {
+-   "holding": {"1": 401, "2": 0, ...},
+-   "input": {"3001": 123, ...}
+- }
+-Missing registers are initialised to 0.
+-"""
+-
+-from __future__ import annotations
+-
+-import argparse
+-import asyncio
+-import contextlib
+-import json
+-import logging
+-import importlib, inspect
+-from dataclasses import dataclass
+-from pathlib import Path
+-from contextlib import asynccontextmanager
+-from typing import Any, Callable, Dict, Iterable, Tuple
+-
+-from pymodbus.datastore import (
+-    ModbusServerContext,
+-    ModbusDeviceContext,
+-    ModbusSequentialDataBlock,
+-)
+-from pymodbus.framer import FramerType
+-from pymodbus.server import ModbusSerialServer, ModbusTcpServer
+-
+-BASE_PATH = Path(__file__).parent
+-DATASETS_PATH = BASE_PATH / "datasets"
+-
+-_LOGGER = logging.getLogger(__name__)
+-
+-DEVICE_TYPES: dict[str, Tuple[str, str]] = {
+-    # key -> (holding_definition_file, input_definition_file)
+-    "min": ("holding_min.json", "input_min.json"),
+-    # TL-XH variants (MIN 6000XH-TL hybrid) use tl_xh mapping
+-    "tl_xh": ("holding_tl_xh.json", "input_tl_xh.json"),
+-    "min_6000xh_tl": ("holding_tl_xh.json", "input_tl_xh.json"),
+-}
+-
+-DEFAULT_DATASETS: dict[str, str] = {
+-    # Provide realistic baseline for MIN 6000XH-TL based on scans
+-    "min_6000xh_tl": "min_6000xh_tl.json",
+-}
+-
+-
+-def _load_register_definitions(filename: str) -> Dict[int, int]:
+-    """Return a dict of every register address defined (value unused=0)."""
+-    with open(BASE_PATH / filename, "r", encoding="utf-8") as f:
+-        data = json.load(f)
+-    registers: dict[int, int] = {}
+-    for item in data:
+-        number = int(item["number"])
+-        length = int(item.get("length", 1))
+-        for offset in range(length):
+-            registers[number + offset] = 0
+-    return registers
+-
+-
+-def _load_dataset(
+-    dataset_file: Path | None, force_deterministic: bool = False
+-) -> tuple[dict[int, int], dict[int, int]]:
+-    """Load dataset file returning holding and input value dicts.
+-
+-    When no dataset is supplied, provide deterministic non-zero values for input
+-    registers 1 and 2 so tests composing a 32-bit value have a stable baseline.
+-    If force_deterministic is True, set first 32 input registers to 1..32 for test stability.
+-    """
+-    if not dataset_file or not dataset_file.exists():
+-        input_regs = {1: 1, 2: 2}
+-        if force_deterministic:
+-            input_regs = {i: i for i in range(1, 33)}
+-        return {}, input_regs
+-
+-    with open(dataset_file, "r", encoding="utf-8") as f:
+-        raw = json.load(f)
+-
+-    def to_uint16(val: int) -> int:
+-        """Coerce any value into an unsigned 16-bit representation."""
+-        return int(val) & 0xFFFF
+-
+-    holding = {int(k): to_uint16(v) for k, v in raw.get("holding", {}).items()}
+-    input_ = {int(k): to_uint16(v) for k, v in raw.get("input", {}).items()}
+-    if force_deterministic:
+-        # Force deterministic values for the first 32 input registers
+-        for i in range(1, 33):
+-            input_[i] = i
+-    return holding, input_
+-
+-
+-def _max_or_default(keys: Iterable[int]) -> int:
+-    try:
+-        return max(keys)
+-    except ValueError:
+-        return 0
+-
+-
+-def _build_value_arrays(
+-    holding_def: dict[int, int],
+-    input_def: dict[int, int],
+-    holding_values: dict[int, int],
+-    input_values: dict[int, int],
+-    *,
+-    strict_defs: bool = False,
+-):
+-    """Create dense arrays for ModbusSequentialDataBlock.
+-
+-    If strict_defs is False (default), include dataset registers even if not in definition files.
+-    This allows using rich real-world scans without enumerating every register in mapping JSON.
+-    """
+-    MAX_REGISTERS = 4000
+-    hr_array = [0] * MAX_REGISTERS
+-    ir_array = [0] * MAX_REGISTERS
+-
+-    # Overwrite with values from definition and dataset
+-    hr_keys = set(holding_def.keys()) | set(holding_values.keys())
+-    ir_keys = set(input_def.keys()) | set(input_values.keys())
+-    for reg in hr_keys:
+-        if 0 <= reg < MAX_REGISTERS:
+-            hr_array[reg] = holding_values.get(reg, 0)
+-    for reg in ir_keys:
+-        if 0 <= reg < MAX_REGISTERS:
+-            ir_array[reg] = input_values.get(reg, 0)
+-    return hr_array, ir_array
+-
+-
+-# Mutation plug‑in API ---------------------------------------------------------
+-# A mutator is either:
+-#   - a callable mutate(registers: dict[str, dict[int,int]], tick: int) -> None
+-#   - an object with method mutate(registers, tick)
+-# It can adjust in‑memory holding/input register values each simulator tick.
+-
+-
+-class _MutatorWrapper:
+-    def __init__(self, target: Any):
+-        if callable(target) and not hasattr(target, "mutate"):
+-            self._fn = target
+-        else:
+-            self._fn = getattr(target, "mutate")
+-        if not callable(self._fn):
+-            raise TypeError("Mutator has no callable mutate()")
+-
+-    def mutate(self, registers: dict[str, dict[int, int]], tick: int):
+-        self._fn(registers, tick)
+-
+-
+-def _load_mutators(specs: list[str]) -> list[_MutatorWrapper]:
+-    muts: list[_MutatorWrapper] = []
+-    for spec in specs:
+-        try:
+-            mod_name, _, attr = spec.partition(":")
+-            mod = importlib.import_module(mod_name)
+-            obj = getattr(mod, attr) if attr else getattr(mod, "mutate", mod)
+-            # If attribute name given and is a class, instantiate; else use directly
+-            if inspect.isclass(obj):
+-                obj = obj()
+-            muts.append(_MutatorWrapper(obj))
+-        except Exception as e:  # pragma: no cover
+-            print(f"[SIM] Failed to load mutator '{spec}': {e}")
+-    return muts
+-
+-
+-@dataclass
+-class SimulatorEndpoint:
+-    """Information about the simulator endpoint."""
+-
+-    mode: str
+-    host: str | None
+-    port: int | None
+-    serial_port: str | None
+-
+-    def __iter__(self):
+-        return iter((self.host, self.port))
+-
+-    def __getitem__(self, index: int):
+-        if index == 0:
+-            return self.host
+-        if index == 1:
+-            return self.port
+-        raise IndexError(index)
+-
+-
+-@asynccontextmanager
+-async def start_simulator(
+-    *args,
+-    port: int = 5020,
+-    host: str = "127.0.0.1",
+-    device: str = "min_6000xh_tl",
+-    dataset: str | None = None,
+-    force_deterministic: bool = False,
+-    strict_defs: bool = False,
+-    mutators: list[str] | None = None,
+-    debug_wire: bool = False,
+-    mode: str = "tcp",
+-    serial_port: str | None = None,
+-    serial_baudrate: int = 9600,
+-    serial_stopbits: int = 1,
+-    serial_bytesize: int = 8,
+-    serial_parity: str = "N",
+-    serial_timeout: float = 1.0,
+-    serial_handle_local_echo: bool = False,
+-):
+-    """Start a Modbus simulator serving predefined registers over TCP or serial.
+-
+-    Backwards compatibility:
+-        Previously accepted a single positional argument (port). Support that pattern while
+-        encouraging keyword usage going forward.
+-    """
+-    if args:
+-        if len(args) == 1 and isinstance(args[0], int):
+-            port = args[0]
+-        else:  # pragma: no cover - defensive
+-            raise TypeError("start_simulator accepts at most one positional int (port)")
+-    # Parameters doc kept above in updated docstring.
+-
+-    if device not in DEVICE_TYPES:
+-        raise ValueError(
+-            f"Unknown device type '{device}'. Valid: {', '.join(DEVICE_TYPES)}"
+-        )
+-
+-    holding_file, input_file = DEVICE_TYPES[device]
+-    holding_def = _load_register_definitions(holding_file)
+-    input_def = _load_register_definitions(input_file)
+-
+-    dataset_path: Path | None = None
+-    if dataset:
+-        dp = Path(dataset)
+-        dataset_path = dp if dp.is_absolute() else (DATASETS_PATH / dataset)
+-    elif device in DEFAULT_DATASETS:
+-        dataset_path = DATASETS_PATH / DEFAULT_DATASETS[device]
+-
+-    holding_values, input_values = _load_dataset(
+-        dataset_path, force_deterministic=force_deterministic
+-    )
+-    hr_values, ir_values = _build_value_arrays(
+-        holding_def, input_def, holding_values, input_values, strict_defs=strict_defs
+-    )
+-
+-    class LoggingDataBlock(ModbusSequentialDataBlock):
+-        def __init__(self, start, values, *, kind: str):
+-            super().__init__(start, values)
+-            self._kind = kind
+-
+-        def getValues(self, address, count=1):  # type: ignore[override]
+-            result = super().getValues(address, count)
+-            if debug_wire:
+-                _LOGGER.debug(
+-                    "%s read %d:%d -> %s",
+-                    self._kind,
+-                    address,
+-                    address + count - 1,
+-                    result,
+-                )
+-            return result
+-
+-        def setValues(self, address, values):  # type: ignore[override]
+-            if debug_wire:
+-                _LOGGER.debug(
+-                    "%s write %d:%d <- %s",
+-                    self._kind,
+-                    address,
+-                    address + len(values) - 1,
+-                    values,
+-                )
+-            return super().setValues(address, values)
+-
+-    # Pymodbus offsets holding-register addresses by +1 for TCP servers.
+-    # Starting the holding block at ``1`` aligns client address ``0`` with
+-    # index ``0`` of ``hr_values``. Input registers do not require this
+-    # offset and therefore retain a base address of ``0``.
+-    hr_block = LoggingDataBlock(1, hr_values, kind="holding")
+-    ir_block = LoggingDataBlock(0, ir_values, kind="input")
+-    store = {1: ModbusDeviceContext(hr=hr_block, ir=ir_block)}
+-    # Pass mapping as first positional arg; current pymodbus expects this without 'slaves=' kw
+-    context = ModbusServerContext(store, single=False)
+-
+-    mode_normalized = mode.lower()
+-    if mode_normalized not in {"tcp", "serial"}:
+-        raise ValueError("mode must be 'tcp' or 'serial'")
+-
+-    if mode_normalized == "serial":
+-        if not serial_port:
+-            raise ValueError("serial_port must be provided when mode='serial'")
+-        parity = (serial_parity or "N").upper()[0]
+-        server = ModbusSerialServer(
+-            context,
+-            framer=FramerType.RTU,
+-            port=serial_port,
+-            baudrate=serial_baudrate,
+-            stopbits=serial_stopbits,
+-            bytesize=serial_bytesize,
+-            parity=parity,
+-            timeout=serial_timeout,
+-            handle_local_echo=serial_handle_local_echo,
+-        )
+-        endpoint = SimulatorEndpoint(
+-            mode="serial",
+-            host=None,
+-            port=None,
+-            serial_port=serial_port,
+-        )
+-        location = serial_port
+-    else:
+-        server = ModbusTcpServer(context, address=(host, port))
+-        endpoint = SimulatorEndpoint(
+-            mode="tcp",
+-            host=host,
+-            port=port,
+-            serial_port=None,
+-        )
+-        location = f"{host}:{port}"
+-
+-    task = asyncio.create_task(server.serve_forever())
+-    log_suffix = ""
+-    if mode_normalized == "serial":
+-        log_suffix = (
+-            f" serial(bps={serial_baudrate},bytes={serial_bytesize},"
+-            f"parity={parity},stop={serial_stopbits},timeout={serial_timeout})"
+-        )
+-    _LOGGER.info(
+-        "Simulator started in %s mode at %s%s (device=%s, dataset=%s defs(h/i)=%d/%d total(h/i)=%d/%d populated(h/i)=%d/%d strict=%s)",
+-        mode_normalized,
+-        location,
+-        log_suffix,
+-        device,
+-        dataset_path.name if dataset_path else "<none>",
+-        len(holding_def),
+-        len(input_def),
+-        len(hr_values),
+-        len(ir_values),
+-        sum(1 for v in hr_values if v != 0),
+-        sum(1 for v in ir_values if v != 0),
+-        strict_defs,
+-    )
+-    _mutators = _load_mutators(mutators or [])
+-    _tick = 0
+-    _stop = asyncio.Event()
+-
+-    async def _mutation_loop():
+-        nonlocal _tick
+-        if not _mutators:
+-            await _stop.wait()
+-            return
+-        while not _stop.is_set():
+-            _tick += 1
+-            regs = {"holding": holding_values, "input": input_values}
+-            for m in _mutators:
+-                try:
+-                    m.mutate(regs, _tick)
+-                except Exception as e:  # pragma: no cover
+-                    print(f"[SIM] mutator error: {e}")
+-            # Apply any changes from mutators back to value arrays
+-            for reg, val in holding_values.items():
+-                hr_block.setValues(reg, [val])
+-            for reg, val in input_values.items():
+-                ir_block.setValues(reg, [val])
+-            try:
+-                await asyncio.wait_for(_stop.wait(), timeout=1.0)
+-            except asyncio.TimeoutError:
+-                pass
+-
+-    mutation_task = asyncio.create_task(_mutation_loop())
+-
+-    try:
+-        # Brief pause to ensure server socket is bound before yielding to caller
+-        await asyncio.sleep(0.05)
+-        yield endpoint
+-    finally:
+-        _stop.set()
+-        mutation_task.cancel()
+-        with contextlib.suppress(asyncio.CancelledError):
+-            await mutation_task
+-        await server.shutdown()
+-        task.cancel()
+-        with contextlib.suppress(asyncio.CancelledError):
+-            await task
+-        _LOGGER.info("Simulator stopped")
+-
+-
+-def _parse_args():
+-    parser = argparse.ArgumentParser(description="Growatt Modbus simulator")
+-    parser.add_argument(
+-        "--mode",
+-        choices=["tcp", "serial"],
+-        default="tcp",
+-        help="Transport to expose (tcp or serial)",
+-    )
+-    parser.add_argument("--port", type=int, default=5020, help="TCP port to listen on")
+-    parser.add_argument(
+-        "--host",
+-        default="127.0.0.1",
+-        help="Host/IP to bind (use 0.0.0.0 for all interfaces)",
+-    )
+-    parser.add_argument(
+-        "--device",
+-        default="min_6000xh_tl",
+-        choices=sorted(DEVICE_TYPES.keys()),
+-        help="Device type mapping to use",
+-    )
+-    parser.add_argument(
+-        "--dataset",
+-        default=None,
+-        help="Dataset JSON (filename in datasets/ or absolute path). Overrides default dataset.",
+-    )
+-    parser.add_argument(
+-        "--strict-defs",
+-        action="store_true",
+-        help="Only include registers present in definition JSON files (ignore extra dataset registers).",
+-    )
+-    parser.add_argument(
+-        "--force-deterministic",
+-        action="store_true",
+-        help="Force first 32 input registers to values 1..32 for test stability.",
+-    )
+-    parser.add_argument(
+-        "--duration",
+-        type=int,
+-        default=0,
+-        help="Optional duration in seconds before auto-shutdown (0 = run forever)",
+-    )
+-    parser.add_argument("--log-level", default="INFO", help="Logging level")
+-    parser.add_argument(
+-        "--mutator",
+-        action="append",
+-        help="Mutation plug‑in spec module[:attr] (repeatable)",
+-    )
+-    parser.add_argument(
+-        "--debug-modbus",
+-        action="store_true",
+-        help="Enable debug logging for all Modbus requests and replies",
+-    )
+-    parser.add_argument(
+-        "--debug-wire",
+-        action="store_true",
+-        help="Log register reads/writes at the simulator layer",
+-    )
+-    parser.add_argument(
+-        "--serial-port",
+-        help="Serial device path to bind when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-baudrate",
+-        type=int,
+-        default=9600,
+-        help="Serial baudrate when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-stopbits",
+-        type=int,
+-        default=1,
+-        help="Serial stop bits when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-bytesize",
+-        type=int,
+-        default=8,
+-        help="Serial byte size when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-parity",
+-        default="N",
+-        help="Serial parity (N/E/O) when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-timeout",
+-        type=float,
+-        default=1.0,
+-        help="Serial timeout in seconds when --mode=serial",
+-    )
+-    parser.add_argument(
+-        "--serial-handle-local-echo",
+-        action="store_true",
+-        help="Discard local echo when running in serial mode",
+-    )
+-    return parser.parse_args()
+-
+-
+-async def _run_cli():
+-    args = _parse_args()
+-    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+-    if args.debug_modbus:
+-        logging.getLogger("pymodbus").setLevel(logging.DEBUG)
+-    if args.mode == "serial" and not args.serial_port:
+-        raise SystemExit("--serial-port is required when --mode=serial")
+-    async with start_simulator(
+-        host=args.host,
+-        port=args.port,
+-        device=args.device,
+-        dataset=args.dataset,
+-        strict_defs=args.strict_defs,
+-        mutators=args.mutator,
+-        debug_wire=args.debug_wire,
+-        force_deterministic=args.force_deterministic,
+-        mode=args.mode,
+-        serial_port=args.serial_port,
+-        serial_baudrate=args.serial_baudrate,
+-        serial_stopbits=args.serial_stopbits,
+-        serial_bytesize=args.serial_bytesize,
+-        serial_parity=args.serial_parity,
+-        serial_timeout=args.serial_timeout,
+-        serial_handle_local_echo=args.serial_handle_local_echo,
+-    ):
+-        if args.duration > 0:
+-            await asyncio.sleep(args.duration)
+-        else:
+-            # Sleep indefinitely
+-            while True:
+-                await asyncio.sleep(3600)
+-
+-
+-if __name__ == "__main__":  # pragma: no cover
+-    try:
+-        asyncio.run(_run_cli())
+-    except KeyboardInterrupt:
+-        pass
+diff --git a/testing/mutators/sample_mutator.py b/testing/mutators/sample_mutator.py
+index 144811c..6c8740f 100644
+--- a/testing/mutators/sample_mutator.py
++++ b/testing/mutators/sample_mutator.py
+@@ -1,7 +1,7 @@
+ """Sample mutation plug‑in for the simulator.
+ 
+ Usage:
+-  python testing/modbus_simulator.py --mutator testing.mutators.sample_mutator:EnergyIncrement
++  python -m growatt_broker.simulator.modbus_simulator --mutator testing.mutators.sample_mutator:EnergyIncrement
+ or shorter if mutate function exported as mutate.
+ 
+ Effect:
+diff --git a/testing/probe_simulator.py b/testing/probe_simulator.py
+index 7e5b0ea..b6255b9 100644
+--- a/testing/probe_simulator.py
++++ b/testing/probe_simulator.py
+@@ -16,7 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
+ if str(ROOT) not in sys.path:
+     sys.path.insert(0, str(ROOT))
+ 
+-from testing.modbus_simulator import start_simulator  # type: ignore
++from growatt_broker.simulator import start_simulator  # type: ignore
+ 
+ 
+ def parse_args():
+diff --git a/tests/conftest.py b/tests/conftest.py
+index 905ba73..0aa5fc9 100644
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -11,7 +11,7 @@ from pymodbus.framer import FramerType
+ from custom_components.growatt_local import GrowattLocalCoordinator
+ from custom_components.growatt_local.API.const import DeviceTypes
+ from custom_components.growatt_local.API.utils import RegisterKeys
+-from testing.modbus_simulator import start_simulator
++from growatt_broker.simulator import start_simulator
+ 
+ 
+ @pytest.fixture(autouse=True, scope="session")
+diff --git a/tests/serial_helpers.py b/tests/serial_helpers.py
+deleted file mode 100644
+index c1e5ea0..0000000
+--- a/tests/serial_helpers.py
++++ /dev/null
+@@ -1,74 +0,0 @@
+-"""Helpers for setting up virtual serial links using socat."""
+-
+-from __future__ import annotations
+-
+-import asyncio
+-import contextlib
+-from contextlib import asynccontextmanager
+-import os
+-import pty
+-import shutil
+-from typing import AsyncIterator, Tuple
+-
+-__all__ = ["virtual_serial_pair", "serial_environment_available"]
+-
+-
+-def serial_environment_available() -> bool:
+-    """Return True if socat and PTY creation are available."""
+-    if shutil.which("socat") is None:
+-        return False
+-    try:
+-        master, slave = pty.openpty()
+-    except OSError:
+-        return False
+-    os.close(master)
+-    os.close(slave)
+-    return True
+-
+-
+-@asynccontextmanager
+-async def virtual_serial_pair() -> AsyncIterator[Tuple[str, str]]:
+-    """Create a connected PTY pair backed by a socat process."""
+-    try:
+-        process = await asyncio.create_subprocess_exec(
+-            "socat",
+-            "-d",
+-            "-d",
+-            "PTY,raw,echo=0",
+-            "PTY,raw,echo=0",
+-            stdout=asyncio.subprocess.DEVNULL,
+-            stderr=asyncio.subprocess.PIPE,
+-        )
+-    except FileNotFoundError as exc:  # pragma: no cover - environment issue
+-        raise RuntimeError("socat is required for serial tests") from exc
+-
+-    ports: list[str] = []
+-    assert process.stderr is not None
+-    log_lines: list[str] = []
+-
+-    try:
+-        while len(ports) < 2:
+-            try:
+-                line = await asyncio.wait_for(process.stderr.readline(), timeout=2.0)
+-            except asyncio.TimeoutError as exc:
+-                raise RuntimeError("Timed out waiting for socat PTY pair") from exc
+-            if not line:
+-                rc = process.returncode
+-                detail = "; ".join(log_lines)
+-                raise RuntimeError(
+-                    "Failed to start socat PTY pair"
+-                    + (f" (rc={rc}): {detail}" if rc is not None else "")
+-                )
+-            text = line.decode().strip()
+-            log_lines.append(text)
+-            if "PTY is" in text:
+-                ports.append(text.split()[-1])
+-            elif " E " in text or text.startswith("E "):
+-                raise RuntimeError(f"socat error: {text}")
+-        # socat prints a final status line before entering transfer loop; consume it
+-        await asyncio.sleep(0)
+-        yield ports[0], ports[1]
+-    finally:
+-        process.terminate()
+-        with contextlib.suppress(ProcessLookupError):
+-            await process.wait()
+diff --git a/tests/test_growatt_api_read_write.py b/tests/test_growatt_api_read_write.py
+index 5edc49c..f6076ad 100644
+--- a/tests/test_growatt_api_read_write.py
++++ b/tests/test_growatt_api_read_write.py
+@@ -54,7 +54,7 @@ from custom_components.growatt_local.API.device_type.base import ATTR_INVERTER_E
+ 
+ 
+ import socket
+-from testing.modbus_simulator import start_simulator
++from growatt_broker.simulator import start_simulator
+ 
+ 
+ @pytest.mark.asyncio
+diff --git a/tests/test_modbus_simulator.py b/tests/test_modbus_simulator.py
+deleted file mode 100644
+index 99e48cd..0000000
+--- a/tests/test_modbus_simulator.py
++++ /dev/null
+@@ -1,214 +0,0 @@
+-import asyncio
+-import socket
+-import importlib
+-import types
+-import sys
+-import json
+-from pathlib import Path
+-
+-import pytest
+-from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
+-from pymodbus.framer import FramerType
+-
+-from testing.modbus_simulator import start_simulator
+-from .serial_helpers import serial_environment_available, virtual_serial_pair
+-
+-pytestmark = pytest.mark.enable_socket
+-SERIAL_AVAILABLE = serial_environment_available()
+-
+-
+-@pytest.mark.asyncio
+-async def test_positional_port_and_custom_host():
+-    # Find a free port first
+-    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
+-    async with start_simulator(port, host="127.0.0.1") as (host, real_port):
+-        assert real_port == port
+-        assert host == "127.0.0.1"
+-        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
+-        await client.connect()
+-        # Brief sleep to ensure server task fully entered serve loop
+-        await asyncio.sleep(0.05)
+-        rr = await client.read_input_registers(0, count=2)
+-        assert not rr.isError()
+-        assert rr.registers == [1, 2]
+-    client.close()
+-
+-
+-@pytest.mark.asyncio
+-async def test_default_dataset_values():
+-    s = socket.socket()
+-    s.bind(("127.0.0.1", 0))
+-    port = s.getsockname()[1]
+-    s.close()
+-    async with start_simulator(port) as (host, real_port):
+-        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
+-        await client.connect()
+-        await asyncio.sleep(0.05)
+-        rr = await client.read_input_registers(0, count=2)
+-        assert not rr.isError()
+-        assert rr.registers == [1, 2]
+-    client.close()
+-
+-
+-@pytest.mark.asyncio
+-@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
+-async def test_default_dataset_values_serial():
+-    async with virtual_serial_pair() as (sim_port, client_port):
+-        async with start_simulator(
+-            mode="serial",
+-            serial_port=sim_port,
+-            force_deterministic=True,
+-        ) as endpoint:
+-            assert endpoint.mode == "serial"
+-            assert endpoint.serial_port == sim_port
+-            client = AsyncModbusSerialClient(
+-                client_port,
+-                framer=FramerType.RTU,
+-                baudrate=9600,
+-                stopbits=1,
+-                bytesize=8,
+-                parity="N",
+-                timeout=1,
+-                reconnect_delay=0,
+-            )
+-            try:
+-                await client.connect()
+-                await asyncio.sleep(0.1)
+-                rr = await client.read_input_registers(0, count=2, device_id=1)
+-                assert not rr.isError()
+-                assert rr.registers == [1, 2]
+-            finally:
+-                client.close()
+-
+-
+-@pytest.mark.asyncio
+-async def test_mutation_plugin_application(tmp_path, monkeypatch):
+-    # Create a temporary module acting as a mutator
+-    mod_path = tmp_path / "temp_mutator.py"
+-    mod_path.write_text(
+-        "tick_values = []\n"
+-        "def mutate(registers, tick):\n"
+-        "    # Increment register 1 each tick starting from existing value\n"
+-        "    registers['input'][1] = registers['input'].get(1, 0) + 10\n"
+-        "    tick_values.append(registers['input'][1])\n"
+-    )
+-    sys.path.insert(0, str(tmp_path))
+-    try:
+-        s = socket.socket()
+-        s.bind(("127.0.0.1", 0))
+-        port = s.getsockname()[1]
+-        s.close()
+-        async with start_simulator(port, mutators=["temp_mutator"]) as (host, real_port):
+-            client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
+-            await client.connect()
+-            # Read initial value after first tick sleep (~0.05s in ctx + <1s before first loop)
+-            await asyncio.sleep(1.2)
+-            # Address 0 maps to our seeded register 1 which the mutator increments
+-            rr1 = await client.read_input_registers(0, count=1)
+-            first = rr1.registers[0]
+-            await asyncio.sleep(1.1)
+-            rr2 = await client.read_input_registers(0, count=1)
+-            second = rr2.registers[0]
+-            assert second > first >= 10  # mutated at least once
+-            client.close()
+-        temp_mod = importlib.import_module("temp_mutator")
+-        assert len(temp_mod.tick_values) >= 2
+-    finally:
+-        if str(tmp_path) in sys.path:
+-            sys.path.remove(str(tmp_path))
+-
+-
+-@pytest.mark.asyncio
+-@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
+-async def test_mutation_plugin_application_serial(tmp_path):
+-    mod_path = tmp_path / "temp_mutator.py"
+-    mod_path.write_text(
+-        "tick_values = []\n"
+-        "def mutate(registers, tick):\n"
+-        "    registers['input'][1] = registers['input'].get(1, 0) + 5\n"
+-        "    tick_values.append(registers['input'][1])\n"
+-    )
+-    sys.path.insert(0, str(tmp_path))
+-    try:
+-        async with virtual_serial_pair() as (sim_port, client_port):
+-            async with start_simulator(
+-                mode="serial",
+-                serial_port=sim_port,
+-                mutators=["temp_mutator"],
+-            ):
+-                client = AsyncModbusSerialClient(
+-                    client_port,
+-                    framer=FramerType.RTU,
+-                    baudrate=9600,
+-                    stopbits=1,
+-                    bytesize=8,
+-                    parity="N",
+-                    timeout=1,
+-                    reconnect_delay=0,
+-                )
+-                try:
+-                    await client.connect()
+-                    await asyncio.sleep(1.2)
+-                    rr1 = await client.read_input_registers(0, count=1, device_id=1)
+-                    first = rr1.registers[0]
+-                    await asyncio.sleep(1.1)
+-                    rr2 = await client.read_input_registers(0, count=1, device_id=1)
+-                    second = rr2.registers[0]
+-                    assert second > first >= 5
+-                finally:
+-                    client.close()
+-        temp_mod = importlib.import_module("temp_mutator")
+-        assert len(temp_mod.tick_values) >= 2
+-    finally:
+-        if str(tmp_path) in sys.path:
+-            sys.path.remove(str(tmp_path))
+-
+-
+-@pytest.mark.asyncio
+-async def test_strict_defs_ignores_extra_dataset(tmp_path):
+-    # Create a minimal dataset with an extra register not in defs
+-    dataset = {"input": {"9999": 123}, "holding": {}}
+-    dataset_path = tmp_path / "ds.json"
+-    dataset_path.write_text(json.dumps(dataset))
+-    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
+-    async with start_simulator(port, dataset=str(dataset_path), strict_defs=True) as (host, real_port):
+-        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
+-        await client.connect()
+-        # 9999 should not exist (not in definition); reading should give 0 or error
+-        rr = await client.read_input_registers(9999, count=1)
+-        if not rr.isError():
+-            assert rr.registers[0] == 0
+-    client.close()
+-
+-
+-@pytest.mark.asyncio
+-@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
+-async def test_strict_defs_ignores_extra_dataset_serial(tmp_path):
+-    dataset = {"input": {"9999": 123}, "holding": {}}
+-    dataset_path = tmp_path / "ds.json"
+-    dataset_path.write_text(json.dumps(dataset))
+-    async with virtual_serial_pair() as (sim_port, client_port):
+-        async with start_simulator(
+-            mode="serial",
+-            serial_port=sim_port,
+-            dataset=str(dataset_path),
+-            strict_defs=True,
+-        ):
+-            client = AsyncModbusSerialClient(
+-                client_port,
+-                framer=FramerType.RTU,
+-                baudrate=9600,
+-                stopbits=1,
+-                bytesize=8,
+-                parity="N",
+-                timeout=1,
+-                reconnect_delay=0,
+-            )
+-            try:
+-                await client.connect()
+-                await asyncio.sleep(0.1)
+-                rr = await client.read_input_registers(9999, count=1, device_id=1)
+-                if not rr.isError():
+-                    assert rr.registers[0] == 0
+-            finally:
+-                client.close()
+diff --git a/tests/test_simulator_register_reads.py b/tests/test_simulator_register_reads.py
+deleted file mode 100644
+index bc9896f..0000000
+--- a/tests/test_simulator_register_reads.py
++++ /dev/null
+@@ -1,94 +0,0 @@
+-"""Test Modbus simulator register reads."""
+-
+-import asyncio
+-import json
+-from pathlib import Path
+-
+-import pytest
+-from pymodbus.client import AsyncModbusTcpClient
+-from pymodbus.framer import FramerType
+-
+-pytestmark = pytest.mark.enable_socket
+-
+-DATASET_PATH = (
+-    Path(__file__).parent.parent / "testing" / "datasets" / "min_6000xh_tl.json"
+-)
+-UNIT_ID = 1
+-
+-
+-@pytest.mark.asyncio
+-async def test_simulator_register_reads():
+-    from testing.modbus_simulator import start_simulator
+-    import socket
+-
+-    # Find free port
+-    s = socket.socket()
+-    s.bind(("127.0.0.1", 0))
+-    port = s.getsockname()[1]
+-    s.close()
+-
+-    # Load expected values from dataset
+-    with DATASET_PATH.open("r", encoding="utf-8") as f:
+-        dataset = json.load(f)
+-    expected = {int(k): int(v) & 0xFFFF for k, v in dataset["holding"].items()}
+-
+-    ranges = [
+-        (0, 124),  # core input block
+-        (3000, 3124),  # mirror of low range
+-        (3125, 3199),  # battery energy counters
+-        (3200, 3231),  # BMS diagnostics
+-        (3232, 3374),  # remaining TL-XH block / reserved
+-    ]
+-
+-    async with start_simulator(
+-        port=port, debug_wire=True, force_deterministic=True
+-    ) as (host, real_port):
+-        client = AsyncModbusTcpClient(
+-            host,
+-            port=real_port,
+-            framer=FramerType.SOCKET,
+-            reconnect_delay=0,
+-        )
+-        await client.connect()
+-        await asyncio.sleep(0.05)
+-        try:
+-            # First: test every register individually
+-            for start, end in ranges:
+-                for addr in range(start, end + 1):
+-                    # rr = await client.read_holding_registers(addr, 1, device_id=1)
+-                    rr = await client.read_holding_registers(addr, count=1, device_id=1)
+-                    assert not rr.isError(), f"Read error at address {addr}"
+-                    reg_val = rr.registers[0]
+-                    expected_val = expected.get(addr, 0)
+-
+-                    # @agent (DEBUG_REPORT.md) : when commenting out the next line,
+-                    # communication gets lost after a certain amount of reads.
+-                    # with line as is, a mismatch is reported, which is another problem
+-                    # alltogether that has to be investigated separately.
+-                    # First problem is to make sure we can read all registers without
+-                    # communication loss.
+-                    assert reg_val == expected_val, (
+-                        f"Mismatch at address {addr}: got {reg_val}, expected {expected_val}"
+-                    )
+-            # Second: test block reads for each range
+-            for start, end in ranges:
+-                total = end - start + 1
+-                offset = start
+-                while total > 0:
+-                    chunk = min(total, 125)
+-                    rr = await client.read_holding_registers(
+-                        offset, count=chunk, device_id=1
+-                    )
+-                    assert not rr.isError(), (
+-                        f"Read error at range {offset}-{offset + chunk - 1}"
+-                    )
+-                    for i, reg_val in enumerate(rr.registers):
+-                        addr = offset + i
+-                        expected_val = expected.get(addr, 0)
+-                        assert reg_val == expected_val, (
+-                            f"Mismatch at address {addr}: got {reg_val}, expected {expected_val}"
+-                        )
+-                    offset += chunk
+-                    total -= chunk
+-        finally:
+-            client.close()

--- a/submodule-patches/external/growatt-rtu-broker/20250916-195747.patch
+++ b/submodule-patches/external/growatt-rtu-broker/20250916-195747.patch
@@ -1,0 +1,2650 @@
+diff --git a/growatt_broker/simulator/__init__.py b/growatt_broker/simulator/__init__.py
+new file mode 100644
+index 0000000..c35db2b
+--- /dev/null
++++ b/growatt_broker/simulator/__init__.py
+@@ -0,0 +1,11 @@
++"""Growatt Modbus simulator utilities."""
++
++from .modbus_simulator import (
++    SimulatorEndpoint,
++    start_simulator,
++)
++
++__all__ = [
++    "SimulatorEndpoint",
++    "start_simulator",
++]
+diff --git a/growatt_broker/simulator/datasets/min_6000xh_tl.json b/growatt_broker/simulator/datasets/min_6000xh_tl.json
+new file mode 100644
+index 0000000..12ec073
+--- /dev/null
++++ b/growatt_broker/simulator/datasets/min_6000xh_tl.json
+@@ -0,0 +1,400 @@
++{
++  "_source": "Derived from scan3.txt in python-modbus-scanner (local copy in testing/python-modbus-scanner/scan3.txt)",
++  "holding": {
++    "3": 100,
++    "5": 10000,
++    "7": -5536,
++    "8": 1000,
++    "9": 16716,
++    "10": 12590,
++    "11": 12288,
++    "13": 25185,
++    "14": 29,
++    "15": 1,
++    "17": 1000,
++    "18": 60,
++    "19": 60,
++    "20": 100,
++    "21": 100,
++    "22": 1,
++    "23": 21326,
++    "24": 19504,
++    "25": 17223,
++    "26": 22064,
++    "27": 12848,
++    "30": 1,
++    "31": 100,
++    "34": 8224,
++    "35": 8272,
++    "36": 22048,
++    "37": 18798,
++    "38": 30309,
++    "39": 29300,
++    "40": 25970,
++    "41": 8224,
++    "43": 5100,
++    "44": 513,
++    "45": 2023,
++    "46": 9,
++    "47": 6,
++    "48": 21,
++    "49": 24,
++    "50": 2,
++    "51": 3,
++    "52": 1840,
++    "53": 2645,
++    "54": 4750,
++    "55": 5150,
++    "56": 1610,
++    "57": 2645,
++    "58": 4750,
++    "59": 5150,
++    "60": 1610,
++    "61": 2645,
++    "62": 4750,
++    "63": 5150,
++    "64": 1955,
++    "65": 2530,
++    "66": 4990,
++    "67": 5010,
++    "68": 100,
++    "69": 50,
++    "70": 50,
++    "71": 50,
++    "72": 50,
++    "73": 50,
++    "74": 50,
++    "75": 50,
++    "76": 50,
++    "77": 50,
++    "78": 10,
++    "79": 10,
++    "80": 2530,
++    "82": 16716,
++    "83": 25185,
++    "84": 12592,
++    "85": 12337,
++    "86": 12337,
++    "87": 12857,
++    "88": 305,
++    "91": 5020,
++    "92": 50,
++    "93": 2484,
++    "94": 2530,
++    "95": 2116,
++    "96": 2070,
++    "97": 20,
++    "98": 5,
++    "99": 2415,
++    "100": 2300,
++    "101": 10000,
++    "102": 10000,
++    "103": 10000,
++    "104": 10000,
++    "105": 10000,
++    "106": 10000,
++    "107": 150,
++    "109": 484,
++    "110": 255,
++    "111": 20000,
++    "112": 255,
++    "113": 20000,
++    "114": 255,
++    "115": 20000,
++    "116": 255,
++    "117": 20000,
++    "118": 15880,
++    "120": 3841,
++    "121": 60,
++    "125": 20566,
++    "126": 8224,
++    "127": 8246,
++    "128": 12336,
++    "129": 12320,
++    "130": 8224,
++    "131": 8224,
++    "132": 8192,
++    "142": 4975,
++    "143": 5020,
++    "146": 1150,
++    "147": 2760,
++    "148": 2530,
++    "149": 2530,
++    "150": 100,
++    "151": 4990,
++    "153": 4800,
++    "155": 5200,
++    "176": 50,
++    "177": 5020,
++    "180": 1,
++    "209": 21326,
++    "210": 19504,
++    "211": 17223,
++    "212": 22064,
++    "213": 12848,
++    "226": 900,
++    "235": 1,
++    "239": 239,
++    "251": 1001,
++    "252": 1002,
++    "253": 1003,
++    "254": 1004,
++    "255": 8,
++    "256": 4,
++    "257": 3,
++    "258": 1,
++    "307": 30,
++    "331": 4900,
++    "332": 5075,
++    "344": 4600,
++    "345": 6500,
++    "501": 10,
++    "502": 1,
++    "507": 72,
++    "508": 1,
++    "509": 1,
++    "533": 1,
++    "534": 6250,
++    "541": 160,
++    "544": 3000,
++    "545": 6000,
++    "546": 9000,
++    "547": 40,
++    "551": 1200,
++    "600": 484,
++    "603": 484,
++    "3001": 21326,
++    "3002": 19504,
++    "3003": 17223,
++    "3004": 22064,
++    "3005": 12848,
++    "3017": 500,
++    "3019": 400,
++    "3020": -30207,
++    "3022": 5500,
++    "3024": 600,
++    "3030": 5800,
++    "3036": 15,
++    "3037": 15,
++    "3038": -32768,
++    "3039": 5947,
++    "3041": 59,
++    "3043": 59,
++    "3047": 50,
++    "3048": 90,
++    "3079": 1,
++    "3087": 20817,
++    "3088": 19249,
++    "3089": 12336,
++    "3090": 12336,
++    "3091": 12850,
++    "3092": 12338,
++    "3093": 12336,
++    "3094": 14667,
++    "3096": 23109,
++    "3097": 16961,
++    "3099": 22083,
++    "3100": 16705,
++    "3101": 2,
++    "3102": 2616,
++    "3103": 2,
++    "3104": 2,
++    "3105": 732,
++    "3108": 16,
++    "3109": 1024,
++    "3111": 48,
++    "3113": 257,
++    "3114": 10,
++    "3125": 22616,
++    "3126": 22616,
++    "3127": 22616,
++    "3128": 22616,
++    "3136": 8224,
++    "3137": 8224
++  },
++  "input": {
++    "1": 1,
++    "2": 2,
++    "3": 14,
++    "4": 262,
++    "6": 4,
++    "7": 357,
++    "10": 10,
++    "36": 6826,
++    "37": 5000,
++    "38": 2278,
++    "39": 29,
++    "41": 6827,
++    "50": 2278,
++    "54": 275,
++    "56": 14039,
++    "57": 152,
++    "58": -28497,
++    "60": 121,
++    "62": 5969,
++    "64": 166,
++    "66": 8922,
++    "92": 14891,
++    "93": 401,
++    "94": 401,
++    "96": 457,
++    "97": 423,
++    "98": 3868,
++    "100": 20000,
++    "113": 11,
++    "114": 60,
++    "182": 1,
++    "183": 1,
++    "189": 26,
++    "190": 35,
++    "191": 375,
++    "192": 6000,
++    "193": 1,
++    "194": 9,
++    "195": 7,
++    "196": 2,
++    "200": -6,
++    "201": 1,
++    "207": 664,
++    "285": 6,
++    "287": 6,
++    "289": 8,
++    "291": 6,
++    "293": 16,
++    "295": 23,
++    "297": 23,
++    "299": 22,
++    "301": 26,
++    "303": 31,
++    "305": 32,
++    "307": 32,
++    "309": 18,
++    "311": 4,
++    "313": 2,
++    "315": 2,
++    "317": 3,
++    "319": 2,
++    "321": 2,
++    "323": 2,
++    "325": 2,
++    "327": 2,
++    "329": 5,
++    "331": 5,
++    "333": 275,
++    "335": 268,
++    "337": 258,
++    "339": 225,
++    "341": 142,
++    "343": 99,
++    "345": 248,
++    "347": 1267,
++    "349": 6772,
++    "351": 5659,
++    "365": 341,
++    "376": 14039,
++    "802": 1,
++    "815": 6829,
++    "3000": 1,
++    "3002": 14,
++    "3003": 262,
++    "3006": 3,
++    "3007": 357,
++    "3010": 11,
++    "3020": 7034,
++    "3024": 6775,
++    "3025": 4998,
++    "3026": 2280,
++    "3027": 30,
++    "3029": 6776,
++    "3038": 2280,
++    "3046": 7074,
++    "3047": 152,
++    "3048": -28393,
++    "3050": 275,
++    "3052": 14039,
++    "3054": 14891,
++    "3056": 121,
++    "3058": 5969,
++    "3060": 166,
++    "3062": 8922,
++    "3068": 9,
++    "3070": 1643,
++    "3072": 181,
++    "3074": 6425,
++    "3076": 118,
++    "3078": 9968,
++    "3084": 287,
++    "3087": -6,
++    "3093": 401,
++    "3094": 401,
++    "3097": 422,
++    "3098": 3867,
++    "3100": 20000,
++    "3101": 11,
++    "3109": 712,
++    "3110": 712,
++    "3111": 290,
++    "3115": 60,
++    "3118": 1,
++    "3122": 7144,
++    "3124": 290,
++    "3126": 53,
++    "3128": 2240,
++    "3130": 50,
++    "3132": 2381,
++    "3136": 44,
++    "3138": 14799,
++    "3140": 109,
++    "3142": 8376,
++    "3161": 10000,
++    "3163": 3900,
++    "3165": 22,
++    "3166": 513,
++    "3169": 21017,
++    "3170": 33,
++    "3171": 63,
++    "3172": 3899,
++    "3173": 1988,
++    "3174": 15,
++    "3175": 15,
++    "3176": 377,
++    "3179": 7080,
++    "3183": 2240,
++    "3185": 2381,
++    "3187": 3,
++    "3188": 1911,
++    "3189": 59,
++    "3190": 41,
++    "3192": 310,
++    "3193": 287,
++    "3194": 2,
++    "3195": 14,
++    "3198": 1,
++    "3200": 50,
++    "3201": 50,
++    "3212": 2,
++    "3215": 63,
++    "3216": 21000,
++    "3217": -340,
++    "3218": 480,
++    "3219": 2500,
++    "3220": 2500,
++    "3222": 100,
++    "3223": 22720,
++    "3224": 18880,
++    "3227": 10536,
++    "3230": 3269,
++    "3231": 3265,
++    "3232": 21010,
++    "3234": 1,
++    "3235": 1,
++    "3241": 26,
++    "3242": 35,
++    "3243": 375,
++    "3244": 6000,
++    "3245": 1,
++    "3246": 9,
++    "3247": 7,
++    "3248": 2
++  }
++}
+\ No newline at end of file
+diff --git a/growatt_broker/simulator/holding_min.json b/growatt_broker/simulator/holding_min.json
+new file mode 100644
+index 0000000..ad1520d
+--- /dev/null
++++ b/growatt_broker/simulator/holding_min.json
+@@ -0,0 +1,434 @@
++[
++  {
++    "number": 0,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Remote On/Off"
++  },
++  {
++    "number": 3,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Max active power %"
++  },
++  {
++    "number": 5,
++    "function_code": "03",
++    "length": 1,
++    "scale": 10000,
++    "unit": "-",
++    "description": "Power factor ×10000"
++  },
++  {
++    "number": 7,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "VA",
++    "description": "Normal power setting"
++  },
++  {
++    "number": 9,
++    "function_code": "03",
++    "length": 3,
++    "scale": 1,
++    "unit": "ASCII",
++    "description": "Firmware version"
++  },
++  {
++    "number": 12,
++    "function_code": "03",
++    "length": 3,
++    "scale": 1,
++    "unit": "ASCII",
++    "description": "Control firmware version"
++  },
++  {
++    "number": 15,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "code",
++    "description": "LCD language"
++  },
++  {
++    "number": 17,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV start voltage"
++  },
++  {
++    "number": 18,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "s",
++    "description": "Start time"
++  },
++  {
++    "number": 19,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "s",
++    "description": "Restart delay after fault"
++  },
++  {
++    "number": 20,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "%/s",
++    "description": "Power slope settings"
++  },
++  {
++    "number": 22,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Baud rate selection"
++  },
++  {
++    "number": 23,
++    "function_code": "03",
++    "length": 5,
++    "scale": 1,
++    "unit": "str",
++    "description": "Serial number (ASCII)"
++  },
++  {
++    "number": 28,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "str",
++    "description": "Inverter model"
++  },
++  {
++    "number": 30,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Communication address"
++  },
++  {
++    "number": 31,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Flash update trigger"
++  },
++  {
++    "number": 34,
++    "function_code": "03",
++    "length": 8,
++    "scale": 1,
++    "unit": "-",
++    "description": "Manufacturer info"
++  },
++  {
++    "number": 43,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "`ATTR_DEVICE_TYPE_CODE`",
++    "description": "Device type code"
++  },
++  {
++    "number": 44,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "`ATTR_NUMBER_OF_TRACKERS_AND_PHASES`",
++    "description": "Tracker + phase count"
++  },
++  {
++    "number": 45,
++    "function_code": "03",
++    "length": 6,
++    "scale": 1,
++    "unit": "-",
++    "description": "Device system time (Y/M/D/H/M/S)"
++  },
++  {
++    "number": 82,
++    "function_code": "03",
++    "length": 6,
++    "scale": 1,
++    "unit": "-",
++    "description": "FW build numbers (ASCII)"
++  },
++  {
++    "number": 88,
++    "function_code": "03",
++    "length": 1,
++    "scale": 100,
++    "unit": "`ATTR_MODBUS_VERSION`",
++    "description": "Modbus version ×100"
++  },
++  {
++    "number": 0,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Remote On/Off (Inverter/BDC)"
++  },
++  {
++    "number": 1,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Safety function enable bits"
++  },
++  {
++    "number": 2,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "PF CMD memory state"
++  },
++  {
++    "number": 3,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Active P rate (limit %)"
++  },
++  {
++    "number": 4,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Reactive P rate (limit %)"
++  },
++  {
++    "number": 5,
++    "function_code": "03",
++    "length": 1,
++    "scale": 10000,
++    "unit": "–",
++    "description": "Power factor ×10000"
++  },
++  {
++    "number": 6,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "VA",
++    "description": "Pmax (high/low)"
++  },
++  {
++    "number": 8,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "Vnormal (PV work voltage)"
++  },
++  {
++    "number": 9,
++    "function_code": "03",
++    "length": 3,
++    "scale": 1,
++    "unit": "–",
++    "description": "Firmware version (H/M/L)"
++  },
++  {
++    "number": 12,
++    "function_code": "03",
++    "length": 3,
++    "scale": 1,
++    "unit": "–",
++    "description": "Control FW version (H/M/L)"
++  },
++  {
++    "number": 15,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "LCD language"
++  },
++  {
++    "number": 16,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Country selected"
++  },
++  {
++    "number": 17,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV start voltage"
++  },
++  {
++    "number": 18,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "s",
++    "description": "Start / Restart delay"
++  },
++  {
++    "number": 20,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "0.1%",
++    "description": "Power start / restart slope"
++  },
++  {
++    "number": 22,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Baudrate select (0=9600,1=38400)"
++  },
++  {
++    "number": 23,
++    "function_code": "03",
++    "length": 5,
++    "scale": 1,
++    "unit": "–",
++    "description": "Serial number (1–10)"
++  },
++  {
++    "number": 28,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "–",
++    "description": "Inverter Module (model code)"
++  },
++  {
++    "number": 30,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Modbus address"
++  },
++  {
++    "number": 31,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "FlashStart (FW update)"
++  },
++  {
++    "number": 32,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "–",
++    "description": "Reset user info / factory"
++  },
++  {
++    "number": 34,
++    "function_code": "03",
++    "length": 8,
++    "scale": 1,
++    "unit": "–",
++    "description": "Manufacturer info (8..1)"
++  },
++  {
++    "number": 42,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "G100 fail safe"
++  },
++  {
++    "number": 43,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Device Type Code"
++  },
++  {
++    "number": 44,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Trackers & phases"
++  },
++  {
++    "number": 45,
++    "function_code": "03",
++    "length": 7,
++    "scale": 1,
++    "unit": "–",
++    "description": "System time (Y/M/D/h/m/s/weekday)"
++  },
++  {
++    "number": 52,
++    "function_code": "03",
++    "length": 16,
++    "scale": 1,
++    "unit": "–",
++    "description": "Grid protection limits"
++  },
++  {
++    "number": 68,
++    "function_code": "03",
++    "length": 12,
++    "scale": 1,
++    "unit": "–",
++    "description": "Grid protection times"
++  },
++  {
++    "number": 80,
++    "function_code": "03",
++    "length": 2,
++    "scale": 1,
++    "unit": "–",
++    "description": "10‑min voltage / PV over‑V fault"
++  },
++  {
++    "number": 82,
++    "function_code": "03",
++    "length": 6,
++    "scale": 1,
++    "unit": "–",
++    "description": "FW build numbers"
++  },
++  {
++    "number": 88,
++    "function_code": "03",
++    "length": 1,
++    "scale": 100,
++    "unit": "–",
++    "description": "Modbus version ×100"
++  },
++  {
++    "number": 89,
++    "function_code": "03",
++    "length": 11,
++    "scale": 1,
++    "unit": "–",
++    "description": "PF/Q(V)/derating controls"
++  }
++]
+\ No newline at end of file
+diff --git a/growatt_broker/simulator/holding_tl_xh.json b/growatt_broker/simulator/holding_tl_xh.json
+new file mode 100644
+index 0000000..ea68aa1
+--- /dev/null
++++ b/growatt_broker/simulator/holding_tl_xh.json
+@@ -0,0 +1,18 @@
++[
++  {
++    "number": 3001,
++    "function_code": "03",
++    "length": 15,
++    "scale": 1,
++    "unit": "–",
++    "description": "Serial number (ASCII, 15 words)"
++  },
++  {
++    "number": 3049,
++    "function_code": "03",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "AC charge enable"
++  }
++]
+\ No newline at end of file
+diff --git a/growatt_broker/simulator/input_min.json b/growatt_broker/simulator/input_min.json
+new file mode 100644
+index 0000000..65952ca
+--- /dev/null
++++ b/growatt_broker/simulator/input_min.json
+@@ -0,0 +1,450 @@
++[
++  {
++    "number": 0,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "int",
++    "description": "Status code"
++  },
++  {
++    "number": 1,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "Total PV input power"
++  },
++  {
++    "number": 3,
++    "function_code": "04",
++    "length": 4,
++    "scale": 1,
++    "unit": "V/A/W",
++    "description": "PV1 V/A/P"
++  },
++  {
++    "number": 7,
++    "function_code": "04",
++    "length": 4,
++    "scale": 1,
++    "unit": "V/A/W",
++    "description": "PV2 V/A/P"
++  },
++  {
++    "number": 35,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "W",
++    "description": "Output power"
++  },
++  {
++    "number": 37,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "Hz",
++    "description": "Grid frequency"
++  },
++  {
++    "number": 38,
++    "function_code": "04",
++    "length": 3,
++    "scale": 1,
++    "unit": "V/A/W",
++    "description": "AC1 V/A/P"
++  },
++  {
++    "number": 53,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Today’s output energy"
++  },
++  {
++    "number": 55,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Total output energy"
++  },
++  {
++    "number": 57,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "h",
++    "description": "Operation hours"
++  },
++  {
++    "number": 59,
++    "function_code": "04",
++    "length": 8,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV1+PV2 today & total energy"
++  },
++  {
++    "number": 91,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV total energy"
++  },
++  {
++    "number": 93,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "Inverter temp"
++  },
++  {
++    "number": 94,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "IPM temp"
++  },
++  {
++    "number": 98,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "P-bus voltage"
++  },
++  {
++    "number": 99,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "N-bus voltage"
++  },
++  {
++    "number": 101,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Output %"
++  },
++  {
++    "number": 104,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Derating mode"
++  },
++  {
++    "number": 105,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Fault code"
++  },
++  {
++    "number": 110,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Warning code"
++  },
++  {
++    "number": 0,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Status code"
++  },
++  {
++    "number": 1,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "PV total input power"
++  },
++  {
++    "number": 3,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV1 voltage"
++  },
++  {
++    "number": 4,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "A",
++    "description": "PV1 current"
++  },
++  {
++    "number": 5,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "PV1 power"
++  },
++  {
++    "number": 7,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV2 voltage"
++  },
++  {
++    "number": 8,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "A",
++    "description": "PV2 current"
++  },
++  {
++    "number": 9,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "PV2 power"
++  },
++  {
++    "number": 11,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV3 voltage"
++  },
++  {
++    "number": 12,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "A",
++    "description": "PV3 current"
++  },
++  {
++    "number": 13,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "PV3 power"
++  },
++  {
++    "number": 15,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "PV4 voltage"
++  },
++  {
++    "number": 16,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "A",
++    "description": "PV4 current"
++  },
++  {
++    "number": 17,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "PV4 power"
++  },
++  {
++    "number": 35,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "W",
++    "description": "Output (AC) power"
++  },
++  {
++    "number": 37,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "Hz",
++    "description": "Grid frequency"
++  },
++  {
++    "number": 38,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "AC1 voltage"
++  },
++  {
++    "number": 39,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "A",
++    "description": "AC1 current"
++  },
++  {
++    "number": 40,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "AC1 power"
++  },
++  {
++    "number": 42,
++    "function_code": "04",
++    "length": 7,
++    "scale": 1,
++    "unit": "–",
++    "description": "AC2/AC3 (3‑phase models)"
++  },
++  {
++    "number": 53,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Today’s output energy"
++  },
++  {
++    "number": 55,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Total output energy"
++  },
++  {
++    "number": 57,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "h",
++    "description": "Operation hours"
++  },
++  {
++    "number": 59,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV1 today’s energy"
++  },
++  {
++    "number": 61,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV1 total energy"
++  },
++  {
++    "number": 63,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV2 today’s energy"
++  },
++  {
++    "number": 65,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV2 total energy"
++  },
++  {
++    "number": 91,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "PV total energy"
++  },
++  {
++    "number": 93,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "Inverter temperature"
++  },
++  {
++    "number": 94,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "IPM temperature"
++  },
++  {
++    "number": 98,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "DC bus voltage P"
++  },
++  {
++    "number": 99,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "V",
++    "description": "DC bus voltage N"
++  },
++  {
++    "number": 101,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Real output %"
++  },
++  {
++    "number": 104,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Derating mode"
++  },
++  {
++    "number": 105,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Fault code"
++  },
++  {
++    "number": 110,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "–",
++    "description": "Warning code"
++  }
++]
+\ No newline at end of file
+diff --git a/growatt_broker/simulator/input_tl_xh.json b/growatt_broker/simulator/input_tl_xh.json
+new file mode 100644
+index 0000000..57345a2
+--- /dev/null
++++ b/growatt_broker/simulator/input_tl_xh.json
+@@ -0,0 +1,298 @@
++[
++  {
++    "number": 3125,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Battery discharge today"
++  },
++  {
++    "number": 3127,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Battery discharge total"
++  },
++  {
++    "number": 3129,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Battery charge today"
++  },
++  {
++    "number": 3131,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "kWh",
++    "description": "Battery charge total"
++  },
++  {
++    "number": 3164,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BDC new flag"
++  },
++  {
++    "number": 3171,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "Battery SOC %"
++  },
++  {
++    "number": 3176,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "Battery temp A"
++  },
++  {
++    "number": 3177,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "Battery temp B"
++  },
++  {
++    "number": 3178,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "Battery discharge power"
++  },
++  {
++    "number": 3180,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "W",
++    "description": "Battery charge power"
++  },
++  {
++    "number": 3202,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Protect1"
++  },
++  {
++    "number": 3203,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Warn1"
++  },
++  {
++    "number": 3204,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Fault1"
++  },
++  {
++    "number": 3205,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Fault2"
++  },
++  {
++    "number": 3210,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Battery ISO detect status"
++  },
++  {
++    "number": 3211,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "Battery request flags"
++  },
++  {
++    "number": 3212,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS status"
++  },
++  {
++    "number": 3213,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Protect2"
++  },
++  {
++    "number": 3214,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Warn2"
++  },
++  {
++    "number": 3215,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "BMS SOC"
++  },
++  {
++    "number": 3216,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "V",
++    "description": "BMS battery voltage"
++  },
++  {
++    "number": 3217,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "A",
++    "description": "BMS battery current"
++  },
++  {
++    "number": 3218,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "°C",
++    "description": "BMS cell max temperature"
++  },
++  {
++    "number": 3219,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "A",
++    "description": "BMS max charge current"
++  },
++  {
++    "number": 3220,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "A",
++    "description": "BMS max discharge current"
++  },
++  {
++    "number": 3221,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS cycle count"
++  },
++  {
++    "number": 3222,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "%",
++    "description": "BMS state of health"
++  },
++  {
++    "number": 3223,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "V",
++    "description": "BMS charge voltage limit"
++  },
++  {
++    "number": 3224,
++    "function_code": "04",
++    "length": 1,
++    "scale": 100,
++    "unit": "V",
++    "description": "BMS discharge voltage limit"
++  },
++  {
++    "number": 3225,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Warn3"
++  },
++  {
++    "number": 3226,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "-",
++    "description": "BMS Protect3"
++  },
++  {
++    "number": 3230,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1000,
++    "unit": "V",
++    "description": "BMS cell voltage max"
++  },
++  {
++    "number": 3231,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1000,
++    "unit": "V",
++    "description": "BMS cell voltage min"
++  },
++  {
++    "number": 3069,
++    "function_code": "04",
++    "length": 2,
++    "scale": 1,
++    "unit": "",
++    "description": "32‑bit field (pair)"
++  },
++  {
++    "number": 3097,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "",
++    "description": "Communication board temperature"
++  },
++  {
++    "number": 3111,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "",
++    "description": "PresentFFTValue \\[CHANNEL_A]"
++  },
++  {
++    "number": 3115,
++    "function_code": "04",
++    "length": 1,
++    "scale": 1,
++    "unit": "",
++    "description": "Inverter start delay time"
++  }
++]
+\ No newline at end of file
+diff --git a/growatt_broker/simulator/modbus_simulator.py b/growatt_broker/simulator/modbus_simulator.py
+new file mode 100644
+index 0000000..0a80eb1
+--- /dev/null
++++ b/growatt_broker/simulator/modbus_simulator.py
+@@ -0,0 +1,529 @@
++"""
++Configurable Modbus TCP/RTU simulator for Growatt devices.
++
++Features:
++ - Support multiple device types via JSON register definition files
++ - Optional dataset JSON with realistic register values (e.g. based on real MIN 6000XH-TL scans)
++ - Supports TCP and serial (RTU) transports for integration and testing
++ - Re-usable async context manager for tests, plus CLI for manual use
++
++JSON definition format (existing):
++ [ {"number": 1, "name": "...", "length": 1}, ... ]
++
++Dataset JSON format:
++ {
++   "holding": {"1": 401, "2": 0, ...},
++   "input": {"3001": 123, ...}
++ }
++Missing registers are initialised to 0.
++"""
++
++from __future__ import annotations
++
++import argparse
++import asyncio
++import contextlib
++import json
++import logging
++import importlib, inspect
++from dataclasses import dataclass
++from pathlib import Path
++from contextlib import asynccontextmanager
++from typing import Any, Callable, Dict, Iterable, Tuple
++
++from pymodbus.datastore import (
++    ModbusServerContext,
++    ModbusDeviceContext,
++    ModbusSequentialDataBlock,
++)
++from pymodbus.framer import FramerType
++from pymodbus.server import ModbusSerialServer, ModbusTcpServer
++
++BASE_PATH = Path(__file__).parent
++DATASETS_PATH = BASE_PATH / "datasets"
++
++_LOGGER = logging.getLogger(__name__)
++
++DEVICE_TYPES: dict[str, Tuple[str, str]] = {
++    # key -> (holding_definition_file, input_definition_file)
++    "min": ("holding_min.json", "input_min.json"),
++    # TL-XH variants (MIN 6000XH-TL hybrid) use tl_xh mapping
++    "tl_xh": ("holding_tl_xh.json", "input_tl_xh.json"),
++    "min_6000xh_tl": ("holding_tl_xh.json", "input_tl_xh.json"),
++}
++
++DEFAULT_DATASETS: dict[str, str] = {
++    # Provide realistic baseline for MIN 6000XH-TL based on scans
++    "min_6000xh_tl": "min_6000xh_tl.json",
++}
++
++
++def _load_register_definitions(filename: str) -> Dict[int, int]:
++    """Return a dict of every register address defined (value unused=0)."""
++    with open(BASE_PATH / filename, "r", encoding="utf-8") as f:
++        data = json.load(f)
++    registers: dict[int, int] = {}
++    for item in data:
++        number = int(item["number"])
++        length = int(item.get("length", 1))
++        for offset in range(length):
++            registers[number + offset] = 0
++    return registers
++
++
++def _load_dataset(
++    dataset_file: Path | None, force_deterministic: bool = False
++) -> tuple[dict[int, int], dict[int, int]]:
++    """Load dataset file returning holding and input value dicts.
++
++    When no dataset is supplied, provide deterministic non-zero values for input
++    registers 1 and 2 so tests composing a 32-bit value have a stable baseline.
++    If force_deterministic is True, set first 32 input registers to 1..32 for test stability.
++    """
++    if not dataset_file or not dataset_file.exists():
++        input_regs = {1: 1, 2: 2}
++        if force_deterministic:
++            input_regs = {i: i for i in range(1, 33)}
++        return {}, input_regs
++
++    with open(dataset_file, "r", encoding="utf-8") as f:
++        raw = json.load(f)
++
++    def to_uint16(val: int) -> int:
++        """Coerce any value into an unsigned 16-bit representation."""
++        return int(val) & 0xFFFF
++
++    holding = {int(k): to_uint16(v) for k, v in raw.get("holding", {}).items()}
++    input_ = {int(k): to_uint16(v) for k, v in raw.get("input", {}).items()}
++    if force_deterministic:
++        # Force deterministic values for the first 32 input registers
++        for i in range(1, 33):
++            input_[i] = i
++    return holding, input_
++
++
++def _max_or_default(keys: Iterable[int]) -> int:
++    try:
++        return max(keys)
++    except ValueError:
++        return 0
++
++
++def _build_value_arrays(
++    holding_def: dict[int, int],
++    input_def: dict[int, int],
++    holding_values: dict[int, int],
++    input_values: dict[int, int],
++    *,
++    strict_defs: bool = False,
++):
++    """Create dense arrays for ModbusSequentialDataBlock.
++
++    If strict_defs is False (default), include dataset registers even if not in definition files.
++    This allows using rich real-world scans without enumerating every register in mapping JSON.
++    """
++    MAX_REGISTERS = 4000
++    hr_array = [0] * MAX_REGISTERS
++    ir_array = [0] * MAX_REGISTERS
++
++    # Overwrite with values from definition and dataset
++    hr_keys = set(holding_def.keys()) | set(holding_values.keys())
++    ir_keys = set(input_def.keys()) | set(input_values.keys())
++    for reg in hr_keys:
++        if 0 <= reg < MAX_REGISTERS:
++            hr_array[reg] = holding_values.get(reg, 0)
++    for reg in ir_keys:
++        if 0 <= reg < MAX_REGISTERS:
++            ir_array[reg] = input_values.get(reg, 0)
++    return hr_array, ir_array
++
++
++# Mutation plug‑in API ---------------------------------------------------------
++# A mutator is either:
++#   - a callable mutate(registers: dict[str, dict[int,int]], tick: int) -> None
++#   - an object with method mutate(registers, tick)
++# It can adjust in‑memory holding/input register values each simulator tick.
++
++
++class _MutatorWrapper:
++    def __init__(self, target: Any):
++        if callable(target) and not hasattr(target, "mutate"):
++            self._fn = target
++        else:
++            self._fn = getattr(target, "mutate")
++        if not callable(self._fn):
++            raise TypeError("Mutator has no callable mutate()")
++
++    def mutate(self, registers: dict[str, dict[int, int]], tick: int):
++        self._fn(registers, tick)
++
++
++def _load_mutators(specs: list[str]) -> list[_MutatorWrapper]:
++    muts: list[_MutatorWrapper] = []
++    for spec in specs:
++        try:
++            mod_name, _, attr = spec.partition(":")
++            mod = importlib.import_module(mod_name)
++            obj = getattr(mod, attr) if attr else getattr(mod, "mutate", mod)
++            # If attribute name given and is a class, instantiate; else use directly
++            if inspect.isclass(obj):
++                obj = obj()
++            muts.append(_MutatorWrapper(obj))
++        except Exception as e:  # pragma: no cover
++            print(f"[SIM] Failed to load mutator '{spec}': {e}")
++    return muts
++
++
++@dataclass
++class SimulatorEndpoint:
++    """Information about the simulator endpoint."""
++
++    mode: str
++    host: str | None
++    port: int | None
++    serial_port: str | None
++
++    def __iter__(self):
++        return iter((self.host, self.port))
++
++    def __getitem__(self, index: int):
++        if index == 0:
++            return self.host
++        if index == 1:
++            return self.port
++        raise IndexError(index)
++
++
++@asynccontextmanager
++async def start_simulator(
++    *args,
++    port: int = 5020,
++    host: str = "127.0.0.1",
++    device: str = "min_6000xh_tl",
++    dataset: str | None = None,
++    force_deterministic: bool = False,
++    strict_defs: bool = False,
++    mutators: list[str] | None = None,
++    debug_wire: bool = False,
++    mode: str = "tcp",
++    serial_port: str | None = None,
++    serial_baudrate: int = 9600,
++    serial_stopbits: int = 1,
++    serial_bytesize: int = 8,
++    serial_parity: str = "N",
++    serial_timeout: float = 1.0,
++    serial_handle_local_echo: bool = False,
++):
++    """Start a Modbus simulator serving predefined registers over TCP or serial.
++
++    Backwards compatibility:
++        Previously accepted a single positional argument (port). Support that pattern while
++        encouraging keyword usage going forward.
++    """
++    if args:
++        if len(args) == 1 and isinstance(args[0], int):
++            port = args[0]
++        else:  # pragma: no cover - defensive
++            raise TypeError("start_simulator accepts at most one positional int (port)")
++    # Parameters doc kept above in updated docstring.
++
++    if device not in DEVICE_TYPES:
++        raise ValueError(
++            f"Unknown device type '{device}'. Valid: {', '.join(DEVICE_TYPES)}"
++        )
++
++    holding_file, input_file = DEVICE_TYPES[device]
++    holding_def = _load_register_definitions(holding_file)
++    input_def = _load_register_definitions(input_file)
++
++    dataset_path: Path | None = None
++    if dataset:
++        dp = Path(dataset)
++        dataset_path = dp if dp.is_absolute() else (DATASETS_PATH / dataset)
++    elif device in DEFAULT_DATASETS:
++        dataset_path = DATASETS_PATH / DEFAULT_DATASETS[device]
++
++    holding_values, input_values = _load_dataset(
++        dataset_path, force_deterministic=force_deterministic
++    )
++    hr_values, ir_values = _build_value_arrays(
++        holding_def, input_def, holding_values, input_values, strict_defs=strict_defs
++    )
++
++    class LoggingDataBlock(ModbusSequentialDataBlock):
++        def __init__(self, start, values, *, kind: str):
++            super().__init__(start, values)
++            self._kind = kind
++
++        def getValues(self, address, count=1):  # type: ignore[override]
++            result = super().getValues(address, count)
++            if debug_wire:
++                _LOGGER.debug(
++                    "%s read %d:%d -> %s",
++                    self._kind,
++                    address,
++                    address + count - 1,
++                    result,
++                )
++            return result
++
++        def setValues(self, address, values):  # type: ignore[override]
++            if debug_wire:
++                _LOGGER.debug(
++                    "%s write %d:%d <- %s",
++                    self._kind,
++                    address,
++                    address + len(values) - 1,
++                    values,
++                )
++            return super().setValues(address, values)
++
++    # Pymodbus offsets holding-register addresses by +1 for TCP servers.
++    # Starting the holding block at ``1`` aligns client address ``0`` with
++    # index ``0`` of ``hr_values``. Input registers do not require this
++    # offset and therefore retain a base address of ``0``.
++    hr_block = LoggingDataBlock(1, hr_values, kind="holding")
++    ir_block = LoggingDataBlock(0, ir_values, kind="input")
++    store = {1: ModbusDeviceContext(hr=hr_block, ir=ir_block)}
++    # Pass mapping as first positional arg; current pymodbus expects this without 'slaves=' kw
++    context = ModbusServerContext(store, single=False)
++
++    mode_normalized = mode.lower()
++    if mode_normalized not in {"tcp", "serial"}:
++        raise ValueError("mode must be 'tcp' or 'serial'")
++
++    if mode_normalized == "serial":
++        if not serial_port:
++            raise ValueError("serial_port must be provided when mode='serial'")
++        parity = (serial_parity or "N").upper()[0]
++        server = ModbusSerialServer(
++            context,
++            framer=FramerType.RTU,
++            port=serial_port,
++            baudrate=serial_baudrate,
++            stopbits=serial_stopbits,
++            bytesize=serial_bytesize,
++            parity=parity,
++            timeout=serial_timeout,
++            handle_local_echo=serial_handle_local_echo,
++        )
++        endpoint = SimulatorEndpoint(
++            mode="serial",
++            host=None,
++            port=None,
++            serial_port=serial_port,
++        )
++        location = serial_port
++    else:
++        server = ModbusTcpServer(context, address=(host, port))
++        endpoint = SimulatorEndpoint(
++            mode="tcp",
++            host=host,
++            port=port,
++            serial_port=None,
++        )
++        location = f"{host}:{port}"
++
++    task = asyncio.create_task(server.serve_forever())
++    log_suffix = ""
++    if mode_normalized == "serial":
++        log_suffix = (
++            f" serial(bps={serial_baudrate},bytes={serial_bytesize},"
++            f"parity={parity},stop={serial_stopbits},timeout={serial_timeout})"
++        )
++    _LOGGER.info(
++        "Simulator started in %s mode at %s%s (device=%s, dataset=%s defs(h/i)=%d/%d total(h/i)=%d/%d populated(h/i)=%d/%d strict=%s)",
++        mode_normalized,
++        location,
++        log_suffix,
++        device,
++        dataset_path.name if dataset_path else "<none>",
++        len(holding_def),
++        len(input_def),
++        len(hr_values),
++        len(ir_values),
++        sum(1 for v in hr_values if v != 0),
++        sum(1 for v in ir_values if v != 0),
++        strict_defs,
++    )
++    _mutators = _load_mutators(mutators or [])
++    _tick = 0
++    _stop = asyncio.Event()
++
++    async def _mutation_loop():
++        nonlocal _tick
++        if not _mutators:
++            await _stop.wait()
++            return
++        while not _stop.is_set():
++            _tick += 1
++            regs = {"holding": holding_values, "input": input_values}
++            for m in _mutators:
++                try:
++                    m.mutate(regs, _tick)
++                except Exception as e:  # pragma: no cover
++                    print(f"[SIM] mutator error: {e}")
++            # Apply any changes from mutators back to value arrays
++            for reg, val in holding_values.items():
++                hr_block.setValues(reg, [val])
++            for reg, val in input_values.items():
++                ir_block.setValues(reg, [val])
++            try:
++                await asyncio.wait_for(_stop.wait(), timeout=1.0)
++            except asyncio.TimeoutError:
++                pass
++
++    mutation_task = asyncio.create_task(_mutation_loop())
++
++    try:
++        # Brief pause to ensure server socket is bound before yielding to caller
++        await asyncio.sleep(0.05)
++        yield endpoint
++    finally:
++        _stop.set()
++        mutation_task.cancel()
++        with contextlib.suppress(asyncio.CancelledError):
++            await mutation_task
++        await server.shutdown()
++        task.cancel()
++        with contextlib.suppress(asyncio.CancelledError):
++            await task
++        _LOGGER.info("Simulator stopped")
++
++
++def _parse_args():
++    parser = argparse.ArgumentParser(description="Growatt Modbus simulator")
++    parser.add_argument(
++        "--mode",
++        choices=["tcp", "serial"],
++        default="tcp",
++        help="Transport to expose (tcp or serial)",
++    )
++    parser.add_argument("--port", type=int, default=5020, help="TCP port to listen on")
++    parser.add_argument(
++        "--host",
++        default="127.0.0.1",
++        help="Host/IP to bind (use 0.0.0.0 for all interfaces)",
++    )
++    parser.add_argument(
++        "--device",
++        default="min_6000xh_tl",
++        choices=sorted(DEVICE_TYPES.keys()),
++        help="Device type mapping to use",
++    )
++    parser.add_argument(
++        "--dataset",
++        default=None,
++        help="Dataset JSON (filename in datasets/ or absolute path). Overrides default dataset.",
++    )
++    parser.add_argument(
++        "--strict-defs",
++        action="store_true",
++        help="Only include registers present in definition JSON files (ignore extra dataset registers).",
++    )
++    parser.add_argument(
++        "--force-deterministic",
++        action="store_true",
++        help="Force first 32 input registers to values 1..32 for test stability.",
++    )
++    parser.add_argument(
++        "--duration",
++        type=int,
++        default=0,
++        help="Optional duration in seconds before auto-shutdown (0 = run forever)",
++    )
++    parser.add_argument("--log-level", default="INFO", help="Logging level")
++    parser.add_argument(
++        "--mutator",
++        action="append",
++        help="Mutation plug‑in spec module[:attr] (repeatable)",
++    )
++    parser.add_argument(
++        "--debug-modbus",
++        action="store_true",
++        help="Enable debug logging for all Modbus requests and replies",
++    )
++    parser.add_argument(
++        "--debug-wire",
++        action="store_true",
++        help="Log register reads/writes at the simulator layer",
++    )
++    parser.add_argument(
++        "--serial-port",
++        help="Serial device path to bind when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-baudrate",
++        type=int,
++        default=9600,
++        help="Serial baudrate when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-stopbits",
++        type=int,
++        default=1,
++        help="Serial stop bits when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-bytesize",
++        type=int,
++        default=8,
++        help="Serial byte size when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-parity",
++        default="N",
++        help="Serial parity (N/E/O) when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-timeout",
++        type=float,
++        default=1.0,
++        help="Serial timeout in seconds when --mode=serial",
++    )
++    parser.add_argument(
++        "--serial-handle-local-echo",
++        action="store_true",
++        help="Discard local echo when running in serial mode",
++    )
++    return parser.parse_args()
++
++
++async def _run_cli():
++    args = _parse_args()
++    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
++    if args.debug_modbus:
++        logging.getLogger("pymodbus").setLevel(logging.DEBUG)
++    if args.mode == "serial" and not args.serial_port:
++        raise SystemExit("--serial-port is required when --mode=serial")
++    async with start_simulator(
++        host=args.host,
++        port=args.port,
++        device=args.device,
++        dataset=args.dataset,
++        strict_defs=args.strict_defs,
++        mutators=args.mutator,
++        debug_wire=args.debug_wire,
++        force_deterministic=args.force_deterministic,
++        mode=args.mode,
++        serial_port=args.serial_port,
++        serial_baudrate=args.serial_baudrate,
++        serial_stopbits=args.serial_stopbits,
++        serial_bytesize=args.serial_bytesize,
++        serial_parity=args.serial_parity,
++        serial_timeout=args.serial_timeout,
++        serial_handle_local_echo=args.serial_handle_local_echo,
++    ):
++        if args.duration > 0:
++            await asyncio.sleep(args.duration)
++        else:
++            # Sleep indefinitely
++            while True:
++                await asyncio.sleep(3600)
++
++
++if __name__ == "__main__":  # pragma: no cover
++    try:
++        asyncio.run(_run_cli())
++    except KeyboardInterrupt:
++        pass
+diff --git a/pyproject.toml b/pyproject.toml
+index 04b512a..0d748b6 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -45,3 +45,6 @@ growatt-broker = "growatt_broker.broker:main"
+ 
+ [tool.pytest.ini_options]
+ addopts = "-q"
++
++[tool.setuptools.package-data]
++"growatt_broker.simulator" = ["*.json", "datasets/*.json"]
+diff --git a/tests/__init__.py b/tests/__init__.py
+new file mode 100644
+index 0000000..e69de29
+diff --git a/tests/conftest.py b/tests/conftest.py
+new file mode 100644
+index 0000000..53359bd
+--- /dev/null
++++ b/tests/conftest.py
+@@ -0,0 +1,44 @@
++"""Pytest configuration for broker tests."""
++
++from __future__ import annotations
++
++import asyncio
++import pytest
++
++# Reset to the default policy so asyncio.get_event_loop() works even when
++# pytest_homeassistant_custom_component is installed in the environment.
++asyncio.set_event_loop_policy(asyncio.DefaultEventLoopPolicy())
++
++
++@pytest.fixture(scope="session", autouse=True)
++def _ensure_event_loop():
++    """Ensure a base event loop exists for plugins that expect one."""
++    try:
++        loop = asyncio.get_event_loop()
++    except RuntimeError:
++        loop = asyncio.new_event_loop()
++        asyncio.set_event_loop(loop)
++        try:
++            yield
++        finally:
++            loop.close()
++    else:
++        yield
++
++
++@pytest.fixture(autouse=True)
++def enable_event_loop_debug():
++    """Override HA plugin fixture that requires a hass event loop."""
++    yield
++
++
++@pytest.fixture(autouse=True)
++def verify_cleanup():
++    """Override HA plugin cleanup fixture to avoid hass loop dependency."""
++    yield
++
++
++@pytest.fixture(autouse=True)
++def _enable_socket(socket_enabled):
++    """Allow network access for tests requiring sockets."""
++    yield
+diff --git a/tests/serial_helpers.py b/tests/serial_helpers.py
+new file mode 100644
+index 0000000..c1e5ea0
+--- /dev/null
++++ b/tests/serial_helpers.py
+@@ -0,0 +1,74 @@
++"""Helpers for setting up virtual serial links using socat."""
++
++from __future__ import annotations
++
++import asyncio
++import contextlib
++from contextlib import asynccontextmanager
++import os
++import pty
++import shutil
++from typing import AsyncIterator, Tuple
++
++__all__ = ["virtual_serial_pair", "serial_environment_available"]
++
++
++def serial_environment_available() -> bool:
++    """Return True if socat and PTY creation are available."""
++    if shutil.which("socat") is None:
++        return False
++    try:
++        master, slave = pty.openpty()
++    except OSError:
++        return False
++    os.close(master)
++    os.close(slave)
++    return True
++
++
++@asynccontextmanager
++async def virtual_serial_pair() -> AsyncIterator[Tuple[str, str]]:
++    """Create a connected PTY pair backed by a socat process."""
++    try:
++        process = await asyncio.create_subprocess_exec(
++            "socat",
++            "-d",
++            "-d",
++            "PTY,raw,echo=0",
++            "PTY,raw,echo=0",
++            stdout=asyncio.subprocess.DEVNULL,
++            stderr=asyncio.subprocess.PIPE,
++        )
++    except FileNotFoundError as exc:  # pragma: no cover - environment issue
++        raise RuntimeError("socat is required for serial tests") from exc
++
++    ports: list[str] = []
++    assert process.stderr is not None
++    log_lines: list[str] = []
++
++    try:
++        while len(ports) < 2:
++            try:
++                line = await asyncio.wait_for(process.stderr.readline(), timeout=2.0)
++            except asyncio.TimeoutError as exc:
++                raise RuntimeError("Timed out waiting for socat PTY pair") from exc
++            if not line:
++                rc = process.returncode
++                detail = "; ".join(log_lines)
++                raise RuntimeError(
++                    "Failed to start socat PTY pair"
++                    + (f" (rc={rc}): {detail}" if rc is not None else "")
++                )
++            text = line.decode().strip()
++            log_lines.append(text)
++            if "PTY is" in text:
++                ports.append(text.split()[-1])
++            elif " E " in text or text.startswith("E "):
++                raise RuntimeError(f"socat error: {text}")
++        # socat prints a final status line before entering transfer loop; consume it
++        await asyncio.sleep(0)
++        yield ports[0], ports[1]
++    finally:
++        process.terminate()
++        with contextlib.suppress(ProcessLookupError):
++            await process.wait()
+diff --git a/tests/test_modbus_simulator.py b/tests/test_modbus_simulator.py
+new file mode 100644
+index 0000000..54303d2
+--- /dev/null
++++ b/tests/test_modbus_simulator.py
+@@ -0,0 +1,212 @@
++import asyncio
++import socket
++import importlib
++import sys
++import json
++
++import pytest
++from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient
++from pymodbus.framer import FramerType
++
++from growatt_broker.simulator import start_simulator
++from .serial_helpers import serial_environment_available, virtual_serial_pair
++
++pytestmark = pytest.mark.enable_socket
++SERIAL_AVAILABLE = serial_environment_available()
++
++
++@pytest.mark.asyncio
++async def test_positional_port_and_custom_host():
++    # Find a free port first
++    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
++    async with start_simulator(port, host="127.0.0.1") as (host, real_port):
++        assert real_port == port
++        assert host == "127.0.0.1"
++        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
++        await client.connect()
++        # Brief sleep to ensure server task fully entered serve loop
++        await asyncio.sleep(0.05)
++        rr = await client.read_input_registers(0, count=2)
++        assert not rr.isError()
++        assert rr.registers == [1, 2]
++    client.close()
++
++
++@pytest.mark.asyncio
++async def test_default_dataset_values():
++    s = socket.socket()
++    s.bind(("127.0.0.1", 0))
++    port = s.getsockname()[1]
++    s.close()
++    async with start_simulator(port) as (host, real_port):
++        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
++        await client.connect()
++        await asyncio.sleep(0.05)
++        rr = await client.read_input_registers(0, count=2)
++        assert not rr.isError()
++        assert rr.registers == [1, 2]
++    client.close()
++
++
++@pytest.mark.asyncio
++@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
++async def test_default_dataset_values_serial():
++    async with virtual_serial_pair() as (sim_port, client_port):
++        async with start_simulator(
++            mode="serial",
++            serial_port=sim_port,
++            force_deterministic=True,
++        ) as endpoint:
++            assert endpoint.mode == "serial"
++            assert endpoint.serial_port == sim_port
++            client = AsyncModbusSerialClient(
++                client_port,
++                framer=FramerType.RTU,
++                baudrate=9600,
++                stopbits=1,
++                bytesize=8,
++                parity="N",
++                timeout=1,
++                reconnect_delay=0,
++            )
++            try:
++                await client.connect()
++                await asyncio.sleep(0.1)
++                rr = await client.read_input_registers(0, count=2, device_id=1)
++                assert not rr.isError()
++                assert rr.registers == [1, 2]
++            finally:
++                client.close()
++
++
++@pytest.mark.asyncio
++async def test_mutation_plugin_application(tmp_path, monkeypatch):
++    # Create a temporary module acting as a mutator
++    mod_path = tmp_path / "temp_mutator.py"
++    mod_path.write_text(
++        "tick_values = []\n"
++        "def mutate(registers, tick):\n"
++        "    # Increment register 1 each tick starting from existing value\n"
++        "    registers['input'][1] = registers['input'].get(1, 0) + 10\n"
++        "    tick_values.append(registers['input'][1])\n"
++    )
++    sys.path.insert(0, str(tmp_path))
++    try:
++        s = socket.socket()
++        s.bind(("127.0.0.1", 0))
++        port = s.getsockname()[1]
++        s.close()
++        async with start_simulator(port, mutators=["temp_mutator"]) as (host, real_port):
++            client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
++            await client.connect()
++            # Read initial value after first tick sleep (~0.05s in ctx + <1s before first loop)
++            await asyncio.sleep(1.2)
++            # Address 0 maps to our seeded register 1 which the mutator increments
++            rr1 = await client.read_input_registers(0, count=1)
++            first = rr1.registers[0]
++            await asyncio.sleep(1.1)
++            rr2 = await client.read_input_registers(0, count=1)
++            second = rr2.registers[0]
++            assert second > first >= 10  # mutated at least once
++            client.close()
++        temp_mod = importlib.import_module("temp_mutator")
++        assert len(temp_mod.tick_values) >= 2
++    finally:
++        if str(tmp_path) in sys.path:
++            sys.path.remove(str(tmp_path))
++
++
++@pytest.mark.asyncio
++@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
++async def test_mutation_plugin_application_serial(tmp_path):
++    mod_path = tmp_path / "temp_mutator.py"
++    mod_path.write_text(
++        "tick_values = []\n"
++        "def mutate(registers, tick):\n"
++        "    registers['input'][1] = registers['input'].get(1, 0) + 5\n"
++        "    tick_values.append(registers['input'][1])\n"
++    )
++    sys.path.insert(0, str(tmp_path))
++    try:
++        async with virtual_serial_pair() as (sim_port, client_port):
++            async with start_simulator(
++                mode="serial",
++                serial_port=sim_port,
++                mutators=["temp_mutator"],
++            ):
++                client = AsyncModbusSerialClient(
++                    client_port,
++                    framer=FramerType.RTU,
++                    baudrate=9600,
++                    stopbits=1,
++                    bytesize=8,
++                    parity="N",
++                    timeout=1,
++                    reconnect_delay=0,
++                )
++                try:
++                    await client.connect()
++                    await asyncio.sleep(1.2)
++                    rr1 = await client.read_input_registers(0, count=1, device_id=1)
++                    first = rr1.registers[0]
++                    await asyncio.sleep(1.1)
++                    rr2 = await client.read_input_registers(0, count=1, device_id=1)
++                    second = rr2.registers[0]
++                    assert second > first >= 5
++                finally:
++                    client.close()
++        temp_mod = importlib.import_module("temp_mutator")
++        assert len(temp_mod.tick_values) >= 2
++    finally:
++        if str(tmp_path) in sys.path:
++            sys.path.remove(str(tmp_path))
++
++
++@pytest.mark.asyncio
++async def test_strict_defs_ignores_extra_dataset(tmp_path):
++    # Create a minimal dataset with an extra register not in defs
++    dataset = {"input": {"9999": 123}, "holding": {}}
++    dataset_path = tmp_path / "ds.json"
++    dataset_path.write_text(json.dumps(dataset))
++    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
++    async with start_simulator(port, dataset=str(dataset_path), strict_defs=True) as (host, real_port):
++        client = AsyncModbusTcpClient(host, port=real_port, framer=FramerType.SOCKET, reconnect_delay=0)
++        await client.connect()
++        # 9999 should not exist (not in definition); reading should give 0 or error
++        rr = await client.read_input_registers(9999, count=1)
++        if not rr.isError():
++            assert rr.registers[0] == 0
++    client.close()
++
++
++@pytest.mark.asyncio
++@pytest.mark.skipif(not SERIAL_AVAILABLE, reason="virtual serial ports unavailable")
++async def test_strict_defs_ignores_extra_dataset_serial(tmp_path):
++    dataset = {"input": {"9999": 123}, "holding": {}}
++    dataset_path = tmp_path / "ds.json"
++    dataset_path.write_text(json.dumps(dataset))
++    async with virtual_serial_pair() as (sim_port, client_port):
++        async with start_simulator(
++            mode="serial",
++            serial_port=sim_port,
++            dataset=str(dataset_path),
++            strict_defs=True,
++        ):
++            client = AsyncModbusSerialClient(
++                client_port,
++                framer=FramerType.RTU,
++                baudrate=9600,
++                stopbits=1,
++                bytesize=8,
++                parity="N",
++                timeout=1,
++                reconnect_delay=0,
++            )
++            try:
++                await client.connect()
++                await asyncio.sleep(0.1)
++                rr = await client.read_input_registers(9999, count=1, device_id=1)
++                if not rr.isError():
++                    assert rr.registers[0] == 0
++            finally:
++                client.close()
+diff --git a/tests/test_simulator_register_reads.py b/tests/test_simulator_register_reads.py
+new file mode 100644
+index 0000000..6d52df1
+--- /dev/null
++++ b/tests/test_simulator_register_reads.py
+@@ -0,0 +1,95 @@
++"""Test Modbus simulator register reads."""
++
++import asyncio
++import json
++import importlib.resources as resources
++
++import pytest
++from pymodbus.client import AsyncModbusTcpClient
++from pymodbus.framer import FramerType
++
++from growatt_broker.simulator import start_simulator
++
++pytestmark = pytest.mark.enable_socket
++
++DATASET_PATH = resources.files("growatt_broker.simulator.datasets").joinpath(
++    "min_6000xh_tl.json"
++)
++UNIT_ID = 1
++
++
++@pytest.mark.asyncio
++async def test_simulator_register_reads():
++    import socket
++
++    # Find free port
++    s = socket.socket()
++    s.bind(("127.0.0.1", 0))
++    port = s.getsockname()[1]
++    s.close()
++
++    # Load expected values from dataset
++    with DATASET_PATH.open("r", encoding="utf-8") as f:
++        dataset = json.load(f)
++    expected = {int(k): int(v) & 0xFFFF for k, v in dataset["holding"].items()}
++
++    ranges = [
++        (0, 124),  # core input block
++        (3000, 3124),  # mirror of low range
++        (3125, 3199),  # battery energy counters
++        (3200, 3231),  # BMS diagnostics
++        (3232, 3374),  # remaining TL-XH block / reserved
++    ]
++
++    async with start_simulator(
++        port=port, debug_wire=True, force_deterministic=True
++    ) as (host, real_port):
++        client = AsyncModbusTcpClient(
++            host,
++            port=real_port,
++            framer=FramerType.SOCKET,
++            reconnect_delay=0,
++        )
++        await client.connect()
++        await asyncio.sleep(0.05)
++        try:
++            # First: test every register individually
++            for start, end in ranges:
++                for addr in range(start, end + 1):
++                    # rr = await client.read_holding_registers(addr, 1, device_id=1)
++                    rr = await client.read_holding_registers(addr, count=1, device_id=1)
++                    assert not rr.isError(), f"Read error at address {addr}"
++                    reg_val = rr.registers[0]
++                    expected_val = expected.get(addr, 0)
++
++                    # @agent (DEBUG_REPORT.md) : when commenting out the next line,
++                    # communication gets lost after a certain amount of reads.
++                    # with line as is, a mismatch is reported, which is another problem
++                    # alltogether that has to be investigated separately.
++                    # First problem is to make sure we can read all registers without
++                    # communication loss.
++                    assert reg_val == expected_val, (
++                        f"Mismatch at address {addr}: got {reg_val}, expected {expected_val}"
++                    )
++            # Second: test block reads for each range
++            for start, end in ranges:
++                total = end - start + 1
++                offset = start
++                while total > 0:
++                    chunk = min(total, 125)
++                    rr = await client.read_holding_registers(
++                        offset, count=chunk, device_id=1
++                    )
++                    assert not rr.isError(), (
++                        f"Read error at range {offset}-{offset + chunk - 1}"
++                    )
++                    for i, reg_val in enumerate(rr.registers):
++                        addr = offset + i
++                        expected_val = expected.get(addr, 0)
++                        assert reg_val == expected_val, (
++                            f"Mismatch at address {addr}: got {reg_val}, expected {expected_val}"
++                        )
++                    offset += chunk
++                    total -= chunk
++        finally:
++            client.close()


### PR DESCRIPTION
## Summary
- relocate the Modbus simulator, register definitions, datasets, and simulator-specific tests into the growatt-rtu-broker package
- update the Homeassistant-Growatt-Local-Modbus integration to consume the broker-hosted simulator, refresh documentation, and clean up obsolete simulator assets
- adjust the submodule pre-commit helper so it ignores the inherited GIT_INDEX_FILE while capturing patches

## Testing
- pytest external/Homeassistant-Growatt-Local-Modbus/tests
- pytest external/growatt-rtu-broker/tests

------
https://chatgpt.com/codex/tasks/task_e_68c9bcf07280833090a4b3295fa9a3ef